### PR TITLE
feat: redesign app shell and add new pages

### DIFF
--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -1,6 +1,7 @@
 import "@rainbow-me/rainbowkit/styles.css";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
+import { MainLayout } from "~~/components/layout/MainLayout";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
@@ -14,7 +15,9 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
     <html suppressHydrationWarning className={``}>
       <body>
         <ThemeProvider enableSystem>
-          <ScaffoldEthAppWithProviders>{children}</ScaffoldEthAppWithProviders>
+          <ScaffoldEthAppWithProviders>
+            <MainLayout>{children}</MainLayout>
+          </ScaffoldEthAppWithProviders>
         </ThemeProvider>
       </body>
     </html>

--- a/packages/nextjs/app/nft/page.tsx
+++ b/packages/nextjs/app/nft/page.tsx
@@ -1,0 +1,185 @@
+import Link from "next/link";
+import type { NextPage } from "next";
+import { CalendarDaysIcon, ClockIcon, SparklesIcon } from "@heroicons/react/24/outline";
+
+const COLLECTIONS = [
+  {
+    id: "Genesis 001",
+    title: "Butterfly Dawn",
+    description: "首批核心成员凭证，享受治理投票与专属空投。",
+    total: 888,
+    minted: 562,
+    price: "0.08 ETH",
+    start: "2025/03/01 12:00",
+    whitelist: "已开启白名单预约",
+    highlight: true,
+  },
+  {
+    id: "Genesis 002",
+    title: "Butterfly Aurora",
+    description: "赋予限时商城折扣与线下活动贵宾通道。",
+    total: 1688,
+    minted: 724,
+    price: "0.12 ETH",
+    start: "2025/04/12 20:00",
+    whitelist: "白名单申请即将开放",
+    highlight: false,
+  },
+  {
+    id: "Limited X",
+    title: "Butterfly Parallel",
+    description: "跨链合作系列，绑定跨界艺术家与现实权益。",
+    total: 520,
+    minted: 98,
+    price: "待公布",
+    start: "2025/05/30 10:00",
+    whitelist: "敬请期待",
+    highlight: false,
+  },
+];
+
+const MintPage: NextPage = () => {
+  return (
+    <div className="space-y-10 text-white">
+      <section className="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center">
+          <div className="flex-1 space-y-5">
+            <p className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/70">
+              NFT Minting Center
+            </p>
+            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">Butterfly NFT 预售中心</h1>
+            <p className="text-sm text-white/70 sm:text-base">
+              加入蝴蝶宇宙的最佳时刻。选择你心仪的系列，完成铸造后即可解锁权益、参与治理与兑换实体周边。
+            </p>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {["实时库存监控", "多链支付支持", "铸造失败自动退款"].map(feature => (
+                <div
+                  key={feature}
+                  className="rounded-2xl border border-white/10 bg-[#0D1F3A]/40 px-4 py-3 text-xs font-medium text-white/80"
+                >
+                  {feature}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex-1">
+            <div className="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#172B54] to-[#253D7C] p-6 shadow-[0_25px_70px_-20px_rgba(10,16,45,0.6)]">
+              <div className="flex items-center gap-4">
+                <SparklesIcon className="h-10 w-10 text-[#8AE7FF]" />
+                <div>
+                  <p className="text-sm uppercase tracking-[0.3em] text-white/60">Mint Status</p>
+                  <h2 className="text-xl font-semibold">当前进度</h2>
+                </div>
+              </div>
+              <div className="mt-6 grid gap-4 text-sm text-white/80">
+                <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/10 px-4 py-3">
+                  <span>已铸造总量</span>
+                  <span>1,384 / 3,096</span>
+                </div>
+                <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/10 px-4 py-3">
+                  <span>累计销毁</span>
+                  <span>86</span>
+                </div>
+                <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/10 px-4 py-3">
+                  <span>社区铸造 Gas 返还</span>
+                  <span>36.2 ETH</span>
+                </div>
+              </div>
+              <Link
+                href="/wallet"
+                className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-white/90 px-5 py-3 text-sm font-semibold text-[#172B54] transition hover:bg-white"
+              >
+                查看我的铸造记录
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.3em] text-white/60">Collections</p>
+            <h2 className="text-2xl font-semibold sm:text-3xl">选择系列并完成铸造</h2>
+          </div>
+          <Link href="/oldhome" className="inline-flex items-center gap-2 text-sm text-[#8AE7FF] hover:text-white">
+            查看旧版控制面板
+          </Link>
+        </div>
+        <div className="space-y-6">
+          {COLLECTIONS.map(collection => {
+            const progress = Math.min(100, Math.round((collection.minted / collection.total) * 100));
+
+            return (
+              <div
+                key={collection.id}
+                className={`rounded-[32px] border border-white/10 p-6 backdrop-blur transition ${
+                  collection.highlight ? "bg-gradient-to-br from-white/15 via-white/5 to-white/10" : "bg-white/5"
+                }`}
+              >
+                <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
+                  <div className="flex-1 space-y-4">
+                    <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-white/60">
+                      <span>{collection.id}</span>
+                      <span className="rounded-full border border-white/20 px-3 py-1">{collection.whitelist}</span>
+                    </div>
+                    <h3 className="text-2xl font-semibold">{collection.title}</h3>
+                    <p className="text-sm text-white/70">{collection.description}</p>
+                    <div className="grid gap-3 sm:grid-cols-3">
+                      {[
+                        { label: "总量", value: collection.total },
+                        { label: "已铸造", value: collection.minted },
+                        { label: "价格", value: collection.price },
+                      ].map(item => (
+                        <div
+                          key={item.label}
+                          className="rounded-2xl border border-white/10 bg-[#0D1F3A]/40 px-4 py-3 text-sm"
+                        >
+                          <p className="text-white/60">{item.label}</p>
+                          <p className="mt-2 text-lg font-semibold">{item.value}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="w-full max-w-sm space-y-4">
+                    <div className="rounded-3xl border border-white/10 bg-white/5 p-5 text-sm text-white/80">
+                      <div className="flex items-center gap-2 text-white">
+                        <CalendarDaysIcon className="h-5 w-5" />
+                        <span>开售时间</span>
+                      </div>
+                      <p className="mt-2 text-lg font-semibold">{collection.start}</p>
+                      <div className="mt-4 flex items-center gap-2 text-white/70">
+                        <ClockIcon className="h-5 w-5" />
+                        <span>预计耗时 8 秒完成铸造</span>
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-white/60">
+                        <span>进度</span>
+                        <span>{progress}%</span>
+                      </div>
+                      <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
+                        <div
+                          className="h-full rounded-full bg-gradient-to-r from-[#7F5AF0] to-[#2CB1BC]"
+                          style={{ width: `${progress}%` }}
+                        />
+                      </div>
+                    </div>
+                    <Link
+                      href="/wallet"
+                      className="inline-flex w-full items-center justify-center rounded-full bg-gradient-to-r from-[#7F5AF0] to-[#2CB1BC] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[#2CB1BC]/20 transition hover:scale-[1.01]"
+                    >
+                      立即铸造
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default MintPage;

--- a/packages/nextjs/app/oldhome/page.tsx
+++ b/packages/nextjs/app/oldhome/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import type { NextPage } from "next";
+import { useAccount } from "wagmi";
+import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { Address } from "~~/components/scaffold-eth";
+
+const Home: NextPage = () => {
+  const { address: connectedAddress } = useAccount();
+
+  return (
+    <>
+      <div className="flex items-center flex-col grow pt-10">
+        <div className="px-5">
+          <h1 className="text-center">
+            <span className="block text-2xl mb-2">Welcome to</span>
+            <span className="block text-4xl font-bold">Scaffold-ETH 2</span>
+          </h1>
+          <div className="flex justify-center items-center space-x-2 flex-col">
+            <p className="my-2 font-medium">Connected Address:</p>
+            <Address address={connectedAddress} />
+          </div>
+
+          <p className="text-center text-lg">
+            Get started by editing{" "}
+            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
+              packages/nextjs/app/page.tsx
+            </code>
+          </p>
+          <p className="text-center text-lg">
+            Edit your smart contract{" "}
+            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
+              YourContract.sol
+            </code>{" "}
+            in{" "}
+            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
+              packages/hardhat/contracts
+            </code>
+          </p>
+        </div>
+
+        <div className="grow bg-base-300 w-full mt-16 px-8 py-12">
+          <div className="flex justify-center items-center gap-12 flex-col md:flex-row">
+            <div className="flex flex-col bg-base-100 px-10 py-10 text-center items-center max-w-xs rounded-3xl">
+              <BugAntIcon className="h-8 w-8 fill-secondary" />
+              <p>
+                Tinker with your smart contract using the{" "}
+                <Link href="/debug" passHref className="link">
+                  Debug Contracts
+                </Link>{" "}
+                tab.
+              </p>
+            </div>
+            <div className="flex flex-col bg-base-100 px-10 py-10 text-center items-center max-w-xs rounded-3xl">
+              <MagnifyingGlassIcon className="h-8 w-8 fill-secondary" />
+              <p>
+                Explore your local transactions with the{" "}
+                <Link href="/blockexplorer" passHref className="link">
+                  Block Explorer
+                </Link>{" "}
+                tab.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Home;

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -2,212 +2,195 @@
 
 import Link from "next/link";
 import type { NextPage } from "next";
-import { useAccount } from "wagmi";
-import {
-  ArrowRightIcon,
-  CubeTransparentIcon,
-  RocketLaunchIcon,
-  SparklesIcon,
-  UsersIcon,
-  WalletIcon,
-} from "@heroicons/react/24/outline";
-import { Address } from "~~/components/scaffold-eth";
 
-const STATS = [
-  { label: "总交易额", value: "52,438 ETH" },
-  { label: "社区成员", value: "18,942" },
-  { label: "NFT 系列", value: "12" },
+const ASCII_BUTTERFLY = `
+000000011111111110000000
+000001111111111111100000
+000111111111111111111000
+001111111111111111111100
+011111110011111001111110
+111111000011110000111111
+111110000111110000111111
+111100001111111000011111
+011100011111111100011110
+001110111111111110111100
+000111111100001111111000
+000011111000000111110000
+000001110000000011100000
+`;
+
+const HERO_STATS = [
+  { label: "GLOBAL HOLDERS", value: "18.4K" },
+  { label: "NFT VOLUME", value: "52,438 ETH" },
+  { label: "COMMUNITY NODES", value: "128" },
 ];
 
-const ECOSYSTEM = [
+const FEATURE_CARDS = [
   {
-    title: "Butterfly NFT",
-    description: "限量铸造即将开启，解锁独家空投和治理权。",
+    id: "nft",
+    tag: "NFT",
+    title: "Hash butterfly digital art piece",
+    description: "独家限量的 Hash butterfly 数字艺术作品，上链即刻拥有，后续可用于身份、权益与活动的全域通行证。",
+    accent: "from-[#2BFBA2] via-[#23D08F] to-[#178B66]",
+    cta: "前往铸造",
     href: "/nft",
-    icon: SparklesIcon,
-    action: "前往铸造",
   },
   {
-    title: "Butterfly Mall",
-    description: "精选生态伙伴的限量商品，支持 NFT 抵扣。",
-    href: "/#mall",
-    icon: CubeTransparentIcon,
-    action: "探索商城",
-  },
-  {
-    title: "$BFLY Token",
-    description: "生态通证一站式流通，享受质押与分红收益。",
-    href: "/#token",
-    icon: RocketLaunchIcon,
-    action: "了解更多",
+    id: "mall",
+    tag: "MALL",
+    title: "Hash butterfly is superlative",
+    description: "精选生态品牌与限量周边，使用 NFT 即可兑换专属福利，线上线下融合打造全新消费体验。",
+    accent: "from-[#3F51F2] via-[#6036D6] to-[#30187C]",
+    cta: "探索商城",
+    href: "/#ecosystem",
   },
 ];
 
-const STEPS = [
+const ECOSYSTEM_POINTS = [
   {
-    title: "连接钱包",
-    description: "支持多链网络，秒级完成连接。",
+    title: "开放协同的生态网络",
+    copy: "钱包、NFT、商城紧密协同，构建从资产管理到权益兑换的一体化链上生态，降低新用户的入门门槛。",
   },
   {
-    title: "铸造专属 NFT",
-    description: "参与预售与空投活动，抢先获取限量身份。",
+    title: "持续增长的社区共识",
+    copy: "全球节点与线下活动持续扩张，会员通过贡献内容、参与治理即可共享生态成长带来的收益。",
   },
   {
-    title: "加入生态治理",
-    description: "通过投票、提案与贡献获得更多权益。",
+    title: "多场景的应用延展",
+    copy: "结合实体消费、数字身份、游戏娱乐等多元场景，让 Hash butterfly 成为链接虚拟与现实的桥梁。",
   },
+];
+
+const TOKEN_STATS = [
+  { label: "TOKEN NAME", value: "BUTTERFLY" },
+  { label: "CHAIN", value: "ETHEREUM" },
+  { label: "ISSUANCE QUANTITY", value: "3 000 TRILLION" },
+  { label: "UTILITY", value: "GOVERNANCE · STAKING · REWARDS" },
 ];
 
 const Home: NextPage = () => {
-  const { address: connectedAddress } = useAccount();
-
   return (
-    <div className="space-y-12 text-white">
-      <section className="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur lg:p-12">
+    <div className="space-y-12 pb-8 text-white">
+      <section className="overflow-hidden rounded-[32px] border border-[#1A8B5D]/40 bg-gradient-to-br from-[#020807] via-[#072015] to-[#0C3B2D] p-8 shadow-[0_30px_90px_rgba(4,45,30,0.35)] lg:p-12">
         <div className="flex flex-col gap-10 lg:flex-row lg:items-center">
           <div className="flex-1 space-y-6">
-            <p className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm uppercase tracking-[0.3em] text-white/70">
-              Butterfly Web3 Ecosystem
-            </p>
-            <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">构建下一代 ButterFly Web3 社区</h1>
-            <p className="text-base text-white/80 sm:text-lg">
-              链接艺术、社交与金融的多维生态，围绕 NFT、商城和钱包打造沉浸式 Web3 体验。
-            </p>
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-[#1A8B5D]/60 bg-black/40 px-4 py-2 text-xs font-semibold tracking-[0.35em] text-[#5CFFC0]">
+              HASH BUTTERFLY
+            </span>
+            <div>
+              <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
+                Hash butterfly{" "}
+                <span className="bg-gradient-to-r from-[#5CFFC0] via-[#7AFCD6] to-[#9BFFE6] bg-clip-text text-transparent">
+                  ecosystem
+                </span>
+              </h1>
+              <p className="mt-4 max-w-xl text-sm text-white/80 sm:text-base">
+                Hash butterfly 以 NFT 为起点，结合钱包与商城服务，为全球用户打造安全、可信、富有情感连接的 Web3 入口。
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-3">
+              {HERO_STATS.map(stat => (
+                <div
+                  key={stat.label}
+                  className="rounded-2xl border border-white/10 bg-white/5 p-4 text-left text-xs sm:text-sm"
+                >
+                  <p className="uppercase tracking-[0.3em] text-[#5CFFC0]">{stat.label}</p>
+                  <p className="mt-2 text-2xl font-semibold text-white sm:text-3xl">{stat.value}</p>
+                </div>
+              ))}
+            </div>
             <div className="flex flex-col gap-3 sm:flex-row">
               <Link
                 href="/nft"
-                className="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#7F5AF0] to-[#2CB1BC] px-6 py-3 text-sm font-medium text-white shadow-lg shadow-[#2CB1BC]/20 transition-transform hover:scale-[1.02]"
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#5CFFC0] to-[#2DE09E] px-6 py-3 text-sm font-semibold text-black shadow-[0_20px_45px_rgba(43,251,162,0.35)] transition hover:scale-[1.02]"
               >
-                开始铸造
-                <ArrowRightIcon className="h-4 w-4" />
+                开始铸造 NFT
               </Link>
               <Link
                 href="/wallet"
-                className="inline-flex items-center justify-center gap-2 rounded-full border border-white/30 px-6 py-3 text-sm font-medium text-white/90 transition hover:border-white hover:text-white"
+                className="inline-flex items-center justify-center rounded-full border border-white/30 px-6 py-3 text-sm font-semibold text-white/90 transition hover:border-white hover:text-white"
               >
                 查看我的钱包
               </Link>
             </div>
           </div>
           <div className="flex-1">
-            <div className="relative mx-auto max-w-sm overflow-hidden rounded-[28px] border border-white/10 bg-white/5 p-6 shadow-[0_20px_60px_-15px_rgba(14,16,35,0.6)]">
-              <div className="absolute -top-24 left-1/2 h-48 w-48 -translate-x-1/2 rounded-full bg-[#2CB1BC]/30 blur-3xl" />
-              <div className="relative space-y-6">
-                <div>
-                  <p className="text-sm uppercase tracking-[0.3em] text-white/60">Connected Wallet</p>
-                  <div className="mt-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm">
-                    {connectedAddress ? (
-                      <Address address={connectedAddress} format="short" />
-                    ) : (
-                      <span className="text-white/60">尚未连接钱包</span>
-                    )}
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-3 text-sm">
-                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-                    <p className="text-white/60">累计权益</p>
-                    <p className="mt-2 text-xl font-semibold">128,900</p>
-                  </div>
-                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-                    <p className="text-white/60">可领取奖励</p>
-                    <p className="mt-2 text-xl font-semibold">1,280 BFLY</p>
-                  </div>
-                </div>
-                <Link
-                  href="/wallet"
-                  className="inline-flex w-full items-center justify-between rounded-2xl border border-white/10 bg-gradient-to-r from-white/10 to-white/5 px-4 py-3 text-sm font-medium text-white/90 transition hover:from-white/20 hover:to-white/10"
-                >
-                  打开我的资产
-                  <WalletIcon className="h-5 w-5" />
-                </Link>
+            <div className="relative mx-auto w-full max-w-md overflow-hidden rounded-[28px] border border-[#1A8B5D]/40 bg-black/40 p-6">
+              <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_20%_20%,rgba(92,255,192,0.35),transparent_60%)]" />
+              <pre className="whitespace-pre font-mono text-[10px] leading-[12px] text-[#5CFFC0] sm:text-xs sm:leading-[14px]">
+                {ASCII_BUTTERFLY}
+              </pre>
+              <div className="mt-6 space-y-2 text-right text-xs text-white/60">
+                <p>HASH BUTTERFLY DIGITAL DNA</p>
+                <p>ON-CHAIN HASH 0x4bf...f1a</p>
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      <section className="grid gap-4 rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur sm:grid-cols-3">
-        {STATS.map(stat => (
-          <div key={stat.label} className="rounded-3xl border border-white/10 bg-[#0D1F3A]/40 p-6 text-center">
-            <p className="text-sm uppercase tracking-wider text-white/60">{stat.label}</p>
-            <p className="mt-2 text-2xl font-semibold">{stat.value}</p>
-          </div>
+      <section className="space-y-6">
+        {FEATURE_CARDS.map(card => (
+          <article
+            key={card.id}
+            className={`rounded-[32px] border border-white/5 bg-gradient-to-br ${card.accent} p-8 text-black shadow-[0_30px_90px_rgba(20,40,25,0.25)] transition-transform hover:-translate-y-1 sm:p-10`}
+          >
+            <div className="flex flex-col gap-8 sm:flex-row sm:items-start">
+              <div className="flex-1 space-y-4">
+                <span className="text-sm font-semibold tracking-[0.4em] text-black/70">{card.tag}</span>
+                <h2 className="text-2xl font-semibold leading-tight sm:text-3xl">{card.title}</h2>
+                <p className="max-w-2xl text-sm leading-relaxed text-black/80 sm:text-base">{card.description}</p>
+              </div>
+              <div className="flex shrink-0 flex-col items-start gap-3 sm:items-end">
+                <Link
+                  href={card.href}
+                  className="inline-flex items-center justify-center rounded-full border border-black/20 bg-white/70 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-black transition hover:bg-white"
+                >
+                  {card.cta}
+                </Link>
+                <div className="rounded-2xl border border-black/10 bg-white/60 px-4 py-3 text-left text-[11px] font-medium tracking-[0.25em] text-black/60">
+                  HASH BUTTERFLY
+                </div>
+              </div>
+            </div>
+          </article>
         ))}
       </section>
 
-      <section id="mall" className="space-y-6">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <p className="text-sm uppercase tracking-[0.3em] text-white/60">Ecosystem</p>
-            <h2 className="text-2xl font-semibold sm:text-3xl">三位一体的生态矩阵</h2>
-          </div>
-          <Link href="/nft" className="inline-flex items-center gap-2 text-sm text-[#8AE7FF] hover:text-white">
-            查看全部功能
-            <ArrowRightIcon className="h-4 w-4" />
-          </Link>
+      <section
+        id="ecosystem"
+        className="space-y-6 rounded-[32px] border border-white/10 bg-[#0A1224]/60 p-8 shadow-[0_25px_70px_rgba(5,10,30,0.45)] sm:p-10"
+      >
+        <div className="space-y-3">
+          <span className="text-xs font-semibold uppercase tracking-[0.4em] text-[#5CFFC0]">
+            Hash butterfly ecosystem
+          </span>
+          <h3 className="text-2xl font-semibold sm:text-3xl">持续扩展的蝴蝶宇宙</h3>
+          <p className="max-w-3xl text-sm text-white/70 sm:text-base">
+            以用户为中心的体验设计，让每一次交互都兼具美感与实用性。从资产的安全托管到权益的灵活使用，Hash butterfly
+            正在打造一个真正面向大众的链上生活方式。
+          </p>
         </div>
         <div className="grid gap-6 sm:grid-cols-3">
-          {ECOSYSTEM.map(card => (
-            <Link
-              key={card.title}
-              href={card.href}
-              className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/5 p-6 transition hover:border-[#8AE7FF]/40 hover:bg-white/10"
-            >
-              <card.icon className="h-10 w-10 text-[#8AE7FF]" />
-              <h3 className="mt-6 text-xl font-semibold">{card.title}</h3>
-              <p className="mt-3 text-sm text-white/70">{card.description}</p>
-              <span className="mt-8 inline-flex items-center gap-2 text-sm text-[#8AE7FF]">
-                {card.action}
-                <ArrowRightIcon className="h-4 w-4 transition group-hover:translate-x-1" />
-              </span>
-            </Link>
+          {ECOSYSTEM_POINTS.map(point => (
+            <div key={point.title} className="rounded-3xl border border-white/10 bg-white/5 p-6">
+              <h4 className="text-lg font-semibold text-white">{point.title}</h4>
+              <p className="mt-3 text-sm text-white/70">{point.copy}</p>
+            </div>
           ))}
         </div>
       </section>
 
-      <section id="token" className="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
-        <div className="flex flex-col gap-10 lg:flex-row lg:items-center">
-          <div className="flex-1 space-y-4">
-            <p className="text-sm uppercase tracking-[0.3em] text-white/60">How it works</p>
-            <h2 className="text-2xl font-semibold sm:text-3xl">三步开启你的 Web3 旅程</h2>
-            <p className="text-sm text-white/70 sm:text-base">
-              无论你是初次接触 Web3，还是资深玩家，我们都为你准备了清晰的引导和完善的资产管理体验。
-            </p>
-            <div className="grid gap-4 sm:grid-cols-3">
-              {STEPS.map(step => (
-                <div key={step.title} className="rounded-2xl border border-white/10 bg-[#0D1F3A]/40 p-4">
-                  <p className="text-sm font-semibold">{step.title}</p>
-                  <p className="mt-2 text-sm text-white/70">{step.description}</p>
-                </div>
-              ))}
+      <section className="rounded-[32px] border border-[#1A8B5D]/50 bg-gradient-to-r from-black/40 via-[#042316]/80 to-black/40 p-8 text-center sm:p-10">
+        <h4 className="text-xl font-semibold uppercase tracking-[0.4em] text-[#5CFFC0]">Token panel</h4>
+        <p className="mt-3 text-sm text-white/70">所有关键数据完全透明，轻松掌握 Hash butterfly 通证的价值与用途。</p>
+        <div className="mt-8 grid gap-4 sm:grid-cols-2">
+          {TOKEN_STATS.map(stat => (
+            <div key={stat.label} className="rounded-3xl border border-white/10 bg-black/50 p-6">
+              <p className="text-xs font-semibold uppercase tracking-[0.5em] text-[#5CFFC0]">{stat.label}</p>
+              <p className="mt-4 text-2xl font-semibold text-white sm:text-3xl">{stat.value}</p>
             </div>
-          </div>
-          <div className="flex-1 space-y-4">
-            <div className="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#172B54] to-[#1F3A7A] p-6">
-              <div className="flex items-center gap-4">
-                <UsersIcon className="h-10 w-10 text-[#8AE7FF]" />
-                <div>
-                  <p className="text-sm uppercase tracking-[0.3em] text-white/60">Community</p>
-                  <h3 className="text-xl font-semibold">加入全球蝴蝶社区</h3>
-                </div>
-              </div>
-              <p className="mt-4 text-sm text-white/70">
-                参与城市节点、共创活动与线下聚会，与志同道合的伙伴共同构建开放式生态。
-              </p>
-            </div>
-            <div className="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#1F3A7A] to-[#2E4E9B] p-6">
-              <div className="flex items-center gap-4">
-                <RocketLaunchIcon className="h-10 w-10 text-[#FFD166]" />
-                <div>
-                  <p className="text-sm uppercase tracking-[0.3em] text-white/60">Roadmap</p>
-                  <h3 className="text-xl font-semibold">持续迭代的生态蓝图</h3>
-                </div>
-              </div>
-              <p className="mt-4 text-sm text-white/70">
-                从 NFT 铸造、元宇宙空间到实体经济联动，我们将按季度推出关键节点，敬请期待。
-              </p>
-            </div>
-          </div>
+          ))}
         </div>
       </section>
     </div>

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -3,69 +3,214 @@
 import Link from "next/link";
 import type { NextPage } from "next";
 import { useAccount } from "wagmi";
-import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowRightIcon,
+  CubeTransparentIcon,
+  RocketLaunchIcon,
+  SparklesIcon,
+  UsersIcon,
+  WalletIcon,
+} from "@heroicons/react/24/outline";
 import { Address } from "~~/components/scaffold-eth";
+
+const STATS = [
+  { label: "总交易额", value: "52,438 ETH" },
+  { label: "社区成员", value: "18,942" },
+  { label: "NFT 系列", value: "12" },
+];
+
+const ECOSYSTEM = [
+  {
+    title: "Butterfly NFT",
+    description: "限量铸造即将开启，解锁独家空投和治理权。",
+    href: "/nft",
+    icon: SparklesIcon,
+    action: "前往铸造",
+  },
+  {
+    title: "Butterfly Mall",
+    description: "精选生态伙伴的限量商品，支持 NFT 抵扣。",
+    href: "/#mall",
+    icon: CubeTransparentIcon,
+    action: "探索商城",
+  },
+  {
+    title: "$BFLY Token",
+    description: "生态通证一站式流通，享受质押与分红收益。",
+    href: "/#token",
+    icon: RocketLaunchIcon,
+    action: "了解更多",
+  },
+];
+
+const STEPS = [
+  {
+    title: "连接钱包",
+    description: "支持多链网络，秒级完成连接。",
+  },
+  {
+    title: "铸造专属 NFT",
+    description: "参与预售与空投活动，抢先获取限量身份。",
+  },
+  {
+    title: "加入生态治理",
+    description: "通过投票、提案与贡献获得更多权益。",
+  },
+];
 
 const Home: NextPage = () => {
   const { address: connectedAddress } = useAccount();
 
   return (
-    <>
-      <div className="flex items-center flex-col grow pt-10">
-        <div className="px-5">
-          <h1 className="text-center">
-            <span className="block text-2xl mb-2">Welcome to</span>
-            <span className="block text-4xl font-bold">Scaffold-ETH 2</span>
-          </h1>
-          <div className="flex justify-center items-center space-x-2 flex-col">
-            <p className="my-2 font-medium">Connected Address:</p>
-            <Address address={connectedAddress} />
-          </div>
-
-          <p className="text-center text-lg">
-            Get started by editing{" "}
-            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
-              packages/nextjs/app/page.tsx
-            </code>
-          </p>
-          <p className="text-center text-lg">
-            Edit your smart contract{" "}
-            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
-              YourContract.sol
-            </code>{" "}
-            in{" "}
-            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
-              packages/hardhat/contracts
-            </code>
-          </p>
-        </div>
-
-        <div className="grow bg-base-300 w-full mt-16 px-8 py-12">
-          <div className="flex justify-center items-center gap-12 flex-col md:flex-row">
-            <div className="flex flex-col bg-base-100 px-10 py-10 text-center items-center max-w-xs rounded-3xl">
-              <BugAntIcon className="h-8 w-8 fill-secondary" />
-              <p>
-                Tinker with your smart contract using the{" "}
-                <Link href="/debug" passHref className="link">
-                  Debug Contracts
-                </Link>{" "}
-                tab.
-              </p>
-            </div>
-            <div className="flex flex-col bg-base-100 px-10 py-10 text-center items-center max-w-xs rounded-3xl">
-              <MagnifyingGlassIcon className="h-8 w-8 fill-secondary" />
-              <p>
-                Explore your local transactions with the{" "}
-                <Link href="/blockexplorer" passHref className="link">
-                  Block Explorer
-                </Link>{" "}
-                tab.
-              </p>
+    <div className="space-y-12 text-white">
+      <section className="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur lg:p-12">
+        <div className="flex flex-col gap-10 lg:flex-row lg:items-center">
+          <div className="flex-1 space-y-6">
+            <p className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm uppercase tracking-[0.3em] text-white/70">
+              Butterfly Web3 Ecosystem
+            </p>
+            <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">构建下一代 ButterFly Web3 社区</h1>
+            <p className="text-base text-white/80 sm:text-lg">
+              链接艺术、社交与金融的多维生态，围绕 NFT、商城和钱包打造沉浸式 Web3 体验。
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/nft"
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#7F5AF0] to-[#2CB1BC] px-6 py-3 text-sm font-medium text-white shadow-lg shadow-[#2CB1BC]/20 transition-transform hover:scale-[1.02]"
+              >
+                开始铸造
+                <ArrowRightIcon className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/wallet"
+                className="inline-flex items-center justify-center gap-2 rounded-full border border-white/30 px-6 py-3 text-sm font-medium text-white/90 transition hover:border-white hover:text-white"
+              >
+                查看我的钱包
+              </Link>
             </div>
           </div>
+          <div className="flex-1">
+            <div className="relative mx-auto max-w-sm overflow-hidden rounded-[28px] border border-white/10 bg-white/5 p-6 shadow-[0_20px_60px_-15px_rgba(14,16,35,0.6)]">
+              <div className="absolute -top-24 left-1/2 h-48 w-48 -translate-x-1/2 rounded-full bg-[#2CB1BC]/30 blur-3xl" />
+              <div className="relative space-y-6">
+                <div>
+                  <p className="text-sm uppercase tracking-[0.3em] text-white/60">Connected Wallet</p>
+                  <div className="mt-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm">
+                    {connectedAddress ? (
+                      <Address address={connectedAddress} format="short" />
+                    ) : (
+                      <span className="text-white/60">尚未连接钱包</span>
+                    )}
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-3 text-sm">
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-white/60">累计权益</p>
+                    <p className="mt-2 text-xl font-semibold">128,900</p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-white/60">可领取奖励</p>
+                    <p className="mt-2 text-xl font-semibold">1,280 BFLY</p>
+                  </div>
+                </div>
+                <Link
+                  href="/wallet"
+                  className="inline-flex w-full items-center justify-between rounded-2xl border border-white/10 bg-gradient-to-r from-white/10 to-white/5 px-4 py-3 text-sm font-medium text-white/90 transition hover:from-white/20 hover:to-white/10"
+                >
+                  打开我的资产
+                  <WalletIcon className="h-5 w-5" />
+                </Link>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
-    </>
+      </section>
+
+      <section className="grid gap-4 rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur sm:grid-cols-3">
+        {STATS.map(stat => (
+          <div key={stat.label} className="rounded-3xl border border-white/10 bg-[#0D1F3A]/40 p-6 text-center">
+            <p className="text-sm uppercase tracking-wider text-white/60">{stat.label}</p>
+            <p className="mt-2 text-2xl font-semibold">{stat.value}</p>
+          </div>
+        ))}
+      </section>
+
+      <section id="mall" className="space-y-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.3em] text-white/60">Ecosystem</p>
+            <h2 className="text-2xl font-semibold sm:text-3xl">三位一体的生态矩阵</h2>
+          </div>
+          <Link href="/nft" className="inline-flex items-center gap-2 text-sm text-[#8AE7FF] hover:text-white">
+            查看全部功能
+            <ArrowRightIcon className="h-4 w-4" />
+          </Link>
+        </div>
+        <div className="grid gap-6 sm:grid-cols-3">
+          {ECOSYSTEM.map(card => (
+            <Link
+              key={card.title}
+              href={card.href}
+              className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/5 p-6 transition hover:border-[#8AE7FF]/40 hover:bg-white/10"
+            >
+              <card.icon className="h-10 w-10 text-[#8AE7FF]" />
+              <h3 className="mt-6 text-xl font-semibold">{card.title}</h3>
+              <p className="mt-3 text-sm text-white/70">{card.description}</p>
+              <span className="mt-8 inline-flex items-center gap-2 text-sm text-[#8AE7FF]">
+                {card.action}
+                <ArrowRightIcon className="h-4 w-4 transition group-hover:translate-x-1" />
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section id="token" className="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+        <div className="flex flex-col gap-10 lg:flex-row lg:items-center">
+          <div className="flex-1 space-y-4">
+            <p className="text-sm uppercase tracking-[0.3em] text-white/60">How it works</p>
+            <h2 className="text-2xl font-semibold sm:text-3xl">三步开启你的 Web3 旅程</h2>
+            <p className="text-sm text-white/70 sm:text-base">
+              无论你是初次接触 Web3，还是资深玩家，我们都为你准备了清晰的引导和完善的资产管理体验。
+            </p>
+            <div className="grid gap-4 sm:grid-cols-3">
+              {STEPS.map(step => (
+                <div key={step.title} className="rounded-2xl border border-white/10 bg-[#0D1F3A]/40 p-4">
+                  <p className="text-sm font-semibold">{step.title}</p>
+                  <p className="mt-2 text-sm text-white/70">{step.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex-1 space-y-4">
+            <div className="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#172B54] to-[#1F3A7A] p-6">
+              <div className="flex items-center gap-4">
+                <UsersIcon className="h-10 w-10 text-[#8AE7FF]" />
+                <div>
+                  <p className="text-sm uppercase tracking-[0.3em] text-white/60">Community</p>
+                  <h3 className="text-xl font-semibold">加入全球蝴蝶社区</h3>
+                </div>
+              </div>
+              <p className="mt-4 text-sm text-white/70">
+                参与城市节点、共创活动与线下聚会，与志同道合的伙伴共同构建开放式生态。
+              </p>
+            </div>
+            <div className="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#1F3A7A] to-[#2E4E9B] p-6">
+              <div className="flex items-center gap-4">
+                <RocketLaunchIcon className="h-10 w-10 text-[#FFD166]" />
+                <div>
+                  <p className="text-sm uppercase tracking-[0.3em] text-white/60">Roadmap</p>
+                  <h3 className="text-xl font-semibold">持续迭代的生态蓝图</h3>
+                </div>
+              </div>
+              <p className="mt-4 text-sm text-white/70">
+                从 NFT 铸造、元宇宙空间到实体经济联动，我们将按季度推出关键节点，敬请期待。
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
   );
 };
 

--- a/packages/nextjs/app/wallet/page.tsx
+++ b/packages/nextjs/app/wallet/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import Link from "next/link";
+import type { NextPage } from "next";
+import { useAccount } from "wagmi";
+import {
+  ArrowPathRoundedSquareIcon,
+  ArrowUpOnSquareStackIcon,
+  BanknotesIcon,
+  CubeIcon,
+  GiftTopIcon,
+  ShieldCheckIcon,
+  UsersIcon,
+  WalletIcon,
+} from "@heroicons/react/24/outline";
+import { Address } from "~~/components/scaffold-eth";
+
+const QUICK_ACTIONS = [
+  {
+    title: "我的余额",
+    description: "主钱包资产汇总",
+    highlight: "6.82 ETH",
+    icon: BanknotesIcon,
+  },
+  {
+    title: "数字资产",
+    description: "NFT、代币与仓位总览",
+    highlight: "24 项资产",
+    icon: CubeIcon,
+  },
+  {
+    title: "好友邀请",
+    description: "分享链接获得奖励",
+    highlight: "已邀请 18 人",
+    icon: UsersIcon,
+  },
+  {
+    title: "我的 NFT",
+    description: "查看收藏与权益",
+    highlight: "8 个系列",
+    icon: GiftTopIcon,
+  },
+  {
+    title: "订单中心",
+    description: "商城与铸造订单",
+    highlight: "3 个进行中",
+    icon: ArrowPathRoundedSquareIcon,
+  },
+  {
+    title: "安全中心",
+    description: "风险监测与授权管理",
+    highlight: "2 个提醒",
+    icon: ShieldCheckIcon,
+  },
+];
+
+const WalletPage: NextPage = () => {
+  const { address: connectedAddress } = useAccount();
+
+  return (
+    <div className="space-y-10 text-white">
+      <section className="rounded-[32px] border border-white/10 bg-gradient-to-br from-[#14264D] to-[#1E3570] p-8 shadow-[0_25px_70px_-20px_rgba(10,16,45,0.6)]">
+        <div className="flex flex-col gap-8 lg:flex-row lg:items-center">
+          <div className="flex-1 space-y-6">
+            <p className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/70">
+              My Web3 Wallet
+            </p>
+            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">欢迎回来，Butterfly 探索者</h1>
+            <p className="text-sm text-white/70 sm:text-base">
+              在这里统一管理你的资产、NFT、邀请奖励与订单，一站式掌握所有生态权益。
+            </p>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-2xl border border-white/20 bg-white/10 p-5 text-sm">
+                <p className="text-white/60">已连接地址</p>
+                <div className="mt-3 text-base font-medium">
+                  {connectedAddress ? <Address address={connectedAddress} format="short" /> : "尚未连接"}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-white/20 bg-white/10 p-5 text-sm">
+                <p className="text-white/60">会员等级</p>
+                <p className="mt-3 text-2xl font-semibold">Butterfly Lv.3</p>
+                <p className="mt-1 text-xs uppercase tracking-[0.3em] text-white/60">成长值 1820 / 2400</p>
+              </div>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/nft"
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-white/90 px-6 py-3 text-sm font-semibold text-[#172B54] transition hover:bg-white"
+              >
+                铸造更多 NFT
+                <ArrowUpOnSquareStackIcon className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/nft"
+                className="inline-flex items-center justify-center gap-2 rounded-full border border-white/40 px-6 py-3 text-sm font-medium text-white/90 transition hover:border-white hover:text-white"
+              >
+                查看权益攻略
+              </Link>
+            </div>
+          </div>
+          <div className="w-full max-w-sm space-y-4">
+            <div className="rounded-[28px] border border-white/20 bg-white/10 p-6">
+              <div className="flex items-center gap-3">
+                <WalletIcon className="h-10 w-10 text-[#8AE7FF]" />
+                <div>
+                  <p className="text-xs uppercase tracking-[0.3em] text-white/60">Overview</p>
+                  <h2 className="text-xl font-semibold">资产概览</h2>
+                </div>
+              </div>
+              <div className="mt-6 space-y-4 text-sm text-white/80">
+                <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-[#0D1F3A]/50 px-4 py-3">
+                  <span>可用余额</span>
+                  <span className="text-lg font-semibold">4.12 ETH</span>
+                </div>
+                <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-[#0D1F3A]/50 px-4 py-3">
+                  <span>锁仓质押</span>
+                  <span className="text-lg font-semibold">2.70 ETH</span>
+                </div>
+                <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-[#0D1F3A]/50 px-4 py-3">
+                  <span>可领取奖励</span>
+                  <span className="text-lg font-semibold">1,560 BFLY</span>
+                </div>
+              </div>
+            </div>
+            <div className="rounded-[28px] border border-white/20 bg-[#0D1F3A]/60 p-6 text-sm text-white/80">
+              <div className="flex items-center gap-3 text-white">
+                <ShieldCheckIcon className="h-6 w-6" />
+                <span className="text-sm font-semibold">安全提示</span>
+              </div>
+              <ul className="mt-4 space-y-2">
+                {["检测到 1 个待确认的授权请求", "建议开启交易限额与登录提醒", "关注钓鱼链接，请勿泄露助记词"].map(
+                  alert => (
+                    <li key={alert} className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                      {alert}
+                    </li>
+                  ),
+                )}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.3em] text-white/60">Quick Actions</p>
+            <h2 className="text-2xl font-semibold sm:text-3xl">快速入口</h2>
+          </div>
+          <Link href="/nft" className="inline-flex items-center gap-2 text-sm text-[#8AE7FF] hover:text-white">
+            查看全部功能
+          </Link>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {QUICK_ACTIONS.map(action => (
+            <div
+              key={action.title}
+              className="group rounded-[28px] border border-white/10 bg-white/5 p-6 transition hover:border-[#8AE7FF]/40 hover:bg-white/10"
+            >
+              <action.icon className="h-8 w-8 text-[#8AE7FF]" />
+              <h3 className="mt-5 text-lg font-semibold">{action.title}</h3>
+              <p className="mt-2 text-sm text-white/70">{action.description}</p>
+              <p className="mt-6 text-sm font-medium text-[#8AE7FF]">{action.highlight}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+        <div className="flex flex-col gap-8 lg:flex-row lg:items-start">
+          <div className="flex-1 space-y-4">
+            <p className="text-sm uppercase tracking-[0.3em] text-white/60">Activity</p>
+            <h2 className="text-2xl font-semibold sm:text-3xl">最近资产动态</h2>
+            <div className="space-y-4 text-sm text-white/80">
+              {["成功领取 260 BFLY 奖励", "完成 Butterfly Dawn #238 的铸造", "好友 Alice 成功注册并完成首次交易"].map(
+                item => (
+                  <div key={item} className="rounded-2xl border border-white/10 bg-[#0D1F3A]/40 px-4 py-3">
+                    {item}
+                  </div>
+                ),
+              )}
+            </div>
+          </div>
+          <div className="w-full max-w-md space-y-4">
+            <div className="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#1A2F63] to-[#2D48A4] p-6 text-sm text-white/80">
+              <div className="flex items-center gap-3 text-white">
+                <ArrowPathRoundedSquareIcon className="h-6 w-6" />
+                <span className="text-sm font-semibold">资产同步中</span>
+              </div>
+              <p className="mt-3 text-sm text-white/70">链上数据每 30 秒刷新一次，如有延迟请稍后再试或手动同步。</p>
+              <button className="mt-5 inline-flex items-center justify-center rounded-full border border-white/40 px-5 py-2 text-sm font-medium text-white transition hover:border-white">
+                立即同步
+              </button>
+            </div>
+            <div className="rounded-[28px] border border-white/10 bg-white/5 p-6 text-sm text-white/80">
+              <div className="flex items-center gap-3 text-white">
+                <ArrowUpOnSquareStackIcon className="h-6 w-6" />
+                <span className="text-sm font-semibold">资产导出</span>
+              </div>
+              <p className="mt-3 text-sm text-white/70">
+                一键导出你的资产报表，支持 Excel 与 CSV 格式，方便税务申报与资产审计。
+              </p>
+              <button className="mt-5 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#7F5AF0] to-[#2CB1BC] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#2CB1BC]/20 transition hover:scale-[1.01]">
+                导出报表
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default WalletPage;

--- a/packages/nextjs/components/layout/MainLayout.tsx
+++ b/packages/nextjs/components/layout/MainLayout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import { BottomNav } from "~~/components/navigation/BottomNav";
+
+export const MainLayout = ({ children }: { children: ReactNode }) => {
+  return (
+    <div className="relative min-h-screen bg-gradient-to-b from-[#05070F] via-[#081636] to-[#111E3E] text-white">
+      <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-4 pb-32 pt-8 sm:px-6 lg:px-10">
+        <main className="flex-1">{children}</main>
+      </div>
+      <BottomNav />
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-72 bg-[radial-gradient(circle_at_top,_rgba(56,130,255,0.35),_transparent_70%)]" />
+    </div>
+  );
+};

--- a/packages/nextjs/components/navigation/BottomNav.tsx
+++ b/packages/nextjs/components/navigation/BottomNav.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { ComponentType, SVGProps } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { HomeIcon, SparklesIcon, WalletIcon } from "@heroicons/react/24/outline";
+
+const NAV_ITEMS: Array<{
+  href: string;
+  label: string;
+  Icon: ComponentType<SVGProps<SVGSVGElement>>;
+}> = [
+  { href: "/", label: "Home", Icon: HomeIcon },
+  { href: "/nft", label: "NFT", Icon: SparklesIcon },
+  { href: "/wallet", label: "Wallet", Icon: WalletIcon },
+];
+
+export const BottomNav = () => {
+  const pathname = usePathname() ?? "/";
+
+  return (
+    <nav className="fixed bottom-4 left-1/2 z-50 w-full max-w-3xl -translate-x-1/2 px-4 sm:px-6">
+      <div className="flex items-center justify-between rounded-3xl border border-white/10 bg-white/10 px-4 py-3 text-sm font-medium text-white shadow-lg backdrop-blur">
+        {NAV_ITEMS.map(({ href, label, Icon }) => {
+          const isActive =
+            pathname === href ||
+            (href !== "/" && pathname.startsWith(`${href}`)) ||
+            (href === "/" && pathname.startsWith("/oldhome"));
+
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-1 transition-colors ${
+                isActive ? "text-white" : "text-white/70 hover:text-white"
+              }`}
+            >
+              <Icon className="h-6 w-6" />
+              <span className="text-xs sm:text-sm">{label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};


### PR DESCRIPTION
## Summary
- wrap the app in a new gradient main layout with a floating bottom navigation for mobile-first navigation
- move the legacy scaffold landing experience to /oldhome and replace the index page with the new ecosystem-focused homepage
- add dedicated /nft and /wallet screens that mirror the provided UI with responsive cards, stats, and calls-to-action

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cad3424a508321b30f7cf613f23b96