### PR TITLE
feat: add presale contract and ipfs metadata integration

### DIFF
--- a/nftbuild/json/_metadata.json
+++ b/nftbuild/json/_metadata.json
@@ -2,7 +2,7 @@
   {
     "name": "#1",
     "description": "Pixel Art NFT Collection",
-    "image": "1.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/1.png",
     "dna": "6:background7#45.png-26:body6#17.png-4:pattern13#47.png",
     "edition": 1,
     "date": 1758112206617,
@@ -28,7 +28,7 @@
   {
     "name": "#2",
     "description": "Pixel Art NFT Collection",
-    "image": "2.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/2.png",
     "dna": "6:background7#45.png-10:body19#43.png-7:pattern16#56.png",
     "edition": 2,
     "date": 1758112206693,
@@ -54,7 +54,7 @@
   {
     "name": "#3",
     "description": "Pixel Art NFT Collection",
-    "image": "3.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/3.png",
     "dna": "3:background4#30.png-1:body10#25.png-7:pattern16#56.png",
     "edition": 3,
     "date": 1758112206752,
@@ -80,7 +80,7 @@
   {
     "name": "#4",
     "description": "Pixel Art NFT Collection",
-    "image": "4.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/4.png",
     "dna": "2:background3#25.png-10:body19#43.png-8:pattern17#59.png",
     "edition": 4,
     "date": 1758112206803,
@@ -106,7 +106,7 @@
   {
     "name": "#5",
     "description": "Pixel Art NFT Collection",
-    "image": "5.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/5.png",
     "dna": "8:background9#55.png-7:body16#37.png-12:pattern4#20.png",
     "edition": 5,
     "date": 1758112206865,
@@ -132,7 +132,7 @@
   {
     "name": "#6",
     "description": "Pixel Art NFT Collection",
-    "image": "6.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/6.png",
     "dna": "8:background9#55.png-15:body23#51.png-7:pattern16#56.png",
     "edition": 6,
     "date": 1758112206922,
@@ -158,7 +158,7 @@
   {
     "name": "#7",
     "description": "Pixel Art NFT Collection",
-    "image": "7.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/7.png",
     "dna": "4:background5#35.png-16:body24#53.png-6:pattern15#53.png",
     "edition": 7,
     "date": 1758112206973,
@@ -184,7 +184,7 @@
   {
     "name": "#8",
     "description": "Pixel Art NFT Collection",
-    "image": "8.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/8.png",
     "dna": "8:background9#55.png-14:body22#49.png-16:pattern8#32.png",
     "edition": 8,
     "date": 1758112207023,
@@ -210,7 +210,7 @@
   {
     "name": "#9",
     "description": "Pixel Art NFT Collection",
-    "image": "9.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/9.png",
     "dna": "3:background4#30.png-28:body8#21.png-6:pattern15#53.png",
     "edition": 9,
     "date": 1758112207074,
@@ -236,7 +236,7 @@
   {
     "name": "#10",
     "description": "Pixel Art NFT Collection",
-    "image": "10.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/10.png",
     "dna": "6:background7#45.png-18:body26#57.png-15:pattern7#29.png",
     "edition": 10,
     "date": 1758112207125,
@@ -262,7 +262,7 @@
   {
     "name": "#11",
     "description": "Pixel Art NFT Collection",
-    "image": "11.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/11.png",
     "dna": "1:background2#20.png-5:body14#33.png-6:pattern15#53.png",
     "edition": 11,
     "date": 1758112207178,
@@ -288,7 +288,7 @@
   {
     "name": "#12",
     "description": "Pixel Art NFT Collection",
-    "image": "12.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/12.png",
     "dna": "3:background4#30.png-23:body30#65.png-6:pattern15#53.png",
     "edition": 12,
     "date": 1758112207249,
@@ -314,7 +314,7 @@
   {
     "name": "#13",
     "description": "Pixel Art NFT Collection",
-    "image": "13.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/13.png",
     "dna": "4:background5#35.png-14:body22#49.png-14:pattern6#26.png",
     "edition": 13,
     "date": 1758112207299,
@@ -340,7 +340,7 @@
   {
     "name": "#14",
     "description": "Pixel Art NFT Collection",
-    "image": "14.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/14.png",
     "dna": "5:background6#40.png-15:body23#51.png-0:pattern1#11.png",
     "edition": 14,
     "date": 1758112207350,
@@ -366,7 +366,7 @@
   {
     "name": "#15",
     "description": "Pixel Art NFT Collection",
-    "image": "15.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/15.png",
     "dna": "5:background6#40.png-19:body27#59.png-2:pattern11#41.png",
     "edition": 15,
     "date": 1758112207406,
@@ -392,7 +392,7 @@
   {
     "name": "#16",
     "description": "Pixel Art NFT Collection",
-    "image": "16.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/16.png",
     "dna": "3:background4#30.png-13:body21#47.png-14:pattern6#26.png",
     "edition": 16,
     "date": 1758112207455,
@@ -418,7 +418,7 @@
   {
     "name": "#17",
     "description": "Pixel Art NFT Collection",
-    "image": "17.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/17.png",
     "dna": "4:background5#35.png-18:body26#57.png-14:pattern6#26.png",
     "edition": 17,
     "date": 1758112207505,
@@ -444,7 +444,7 @@
   {
     "name": "#18",
     "description": "Pixel Art NFT Collection",
-    "image": "18.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/18.png",
     "dna": "5:background6#40.png-18:body26#57.png-2:pattern11#41.png",
     "edition": 18,
     "date": 1758112207561,
@@ -470,7 +470,7 @@
   {
     "name": "#19",
     "description": "Pixel Art NFT Collection",
-    "image": "19.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/19.png",
     "dna": "3:background4#30.png-20:body28#61.png-9:pattern18#62.png",
     "edition": 19,
     "date": 1758112207614,
@@ -496,7 +496,7 @@
   {
     "name": "#20",
     "description": "Pixel Art NFT Collection",
-    "image": "20.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/20.png",
     "dna": "2:background3#25.png-21:body29#63.png-15:pattern7#29.png",
     "edition": 20,
     "date": 1758112207666,
@@ -522,7 +522,7 @@
   {
     "name": "#21",
     "description": "Pixel Art NFT Collection",
-    "image": "21.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/21.png",
     "dna": "7:background8#50.png-22:body3#11.png-1:pattern10#38.png",
     "edition": 21,
     "date": 1758112207718,
@@ -548,7 +548,7 @@
   {
     "name": "#22",
     "description": "Pixel Art NFT Collection",
-    "image": "22.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/22.png",
     "dna": "0:background1#15.png-9:body18#41.png-6:pattern15#53.png",
     "edition": 22,
     "date": 1758112207771,
@@ -574,7 +574,7 @@
   {
     "name": "#23",
     "description": "Pixel Art NFT Collection",
-    "image": "23.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/23.png",
     "dna": "7:background8#50.png-8:body17#39.png-9:pattern18#62.png",
     "edition": 23,
     "date": 1758112207828,
@@ -600,7 +600,7 @@
   {
     "name": "#24",
     "description": "Pixel Art NFT Collection",
-    "image": "24.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/24.png",
     "dna": "4:background5#35.png-23:body30#65.png-3:pattern12#44.png",
     "edition": 24,
     "date": 1758112207955,
@@ -626,7 +626,7 @@
   {
     "name": "#25",
     "description": "Pixel Art NFT Collection",
-    "image": "25.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/25.png",
     "dna": "4:background5#35.png-3:body12#29.png-8:pattern17#59.png",
     "edition": 25,
     "date": 1758112208016,
@@ -652,7 +652,7 @@
   {
     "name": "#26",
     "description": "Pixel Art NFT Collection",
-    "image": "26.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/26.png",
     "dna": "0:background1#15.png-20:body28#61.png-3:pattern12#44.png",
     "edition": 26,
     "date": 1758112208073,
@@ -678,7 +678,7 @@
   {
     "name": "#27",
     "description": "Pixel Art NFT Collection",
-    "image": "27.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/27.png",
     "dna": "3:background4#30.png-14:body22#49.png-3:pattern12#44.png",
     "edition": 27,
     "date": 1758112208125,
@@ -704,7 +704,7 @@
   {
     "name": "#28",
     "description": "Pixel Art NFT Collection",
-    "image": "28.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/28.png",
     "dna": "4:background5#35.png-21:body29#63.png-17:pattern9#35.png",
     "edition": 28,
     "date": 1758112208176,
@@ -730,7 +730,7 @@
   {
     "name": "#29",
     "description": "Pixel Art NFT Collection",
-    "image": "29.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/29.png",
     "dna": "4:background5#35.png-7:body16#37.png-9:pattern18#62.png",
     "edition": 29,
     "date": 1758112208227,
@@ -756,7 +756,7 @@
   {
     "name": "#30",
     "description": "Pixel Art NFT Collection",
-    "image": "30.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/30.png",
     "dna": "4:background5#35.png-6:body15#35.png-0:pattern1#11.png",
     "edition": 30,
     "date": 1758112208285,
@@ -782,7 +782,7 @@
   {
     "name": "#31",
     "description": "Pixel Art NFT Collection",
-    "image": "31.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/31.png",
     "dna": "4:background5#35.png-24:body4#13.png-2:pattern11#41.png",
     "edition": 31,
     "date": 1758112208337,
@@ -808,7 +808,7 @@
   {
     "name": "#32",
     "description": "Pixel Art NFT Collection",
-    "image": "32.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/32.png",
     "dna": "5:background6#40.png-25:body5#15.png-14:pattern6#26.png",
     "edition": 32,
     "date": 1758112208392,
@@ -834,7 +834,7 @@
   {
     "name": "#33",
     "description": "Pixel Art NFT Collection",
-    "image": "33.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/33.png",
     "dna": "5:background6#40.png-4:body13#31.png-13:pattern5#23.png",
     "edition": 33,
     "date": 1758112208444,
@@ -860,7 +860,7 @@
   {
     "name": "#34",
     "description": "Pixel Art NFT Collection",
-    "image": "34.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/34.png",
     "dna": "6:background7#45.png-20:body28#61.png-17:pattern9#35.png",
     "edition": 34,
     "date": 1758112208500,
@@ -886,7 +886,7 @@
   {
     "name": "#35",
     "description": "Pixel Art NFT Collection",
-    "image": "35.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/35.png",
     "dna": "4:background5#35.png-13:body21#47.png-15:pattern7#29.png",
     "edition": 35,
     "date": 1758112208550,
@@ -912,7 +912,7 @@
   {
     "name": "#36",
     "description": "Pixel Art NFT Collection",
-    "image": "36.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/36.png",
     "dna": "3:background4#30.png-8:body17#39.png-11:pattern3#17.png",
     "edition": 36,
     "date": 1758112208609,
@@ -938,7 +938,7 @@
   {
     "name": "#37",
     "description": "Pixel Art NFT Collection",
-    "image": "37.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/37.png",
     "dna": "6:background7#45.png-19:body27#59.png-4:pattern13#47.png",
     "edition": 37,
     "date": 1758112208664,
@@ -964,7 +964,7 @@
   {
     "name": "#38",
     "description": "Pixel Art NFT Collection",
-    "image": "38.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/38.png",
     "dna": "7:background8#50.png-6:body15#35.png-3:pattern12#44.png",
     "edition": 38,
     "date": 1758112208715,
@@ -990,7 +990,7 @@
   {
     "name": "#39",
     "description": "Pixel Art NFT Collection",
-    "image": "39.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/39.png",
     "dna": "7:background8#50.png-7:body16#37.png-14:pattern6#26.png",
     "edition": 39,
     "date": 1758112208766,
@@ -1016,7 +1016,7 @@
   {
     "name": "#40",
     "description": "Pixel Art NFT Collection",
-    "image": "40.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/40.png",
     "dna": "8:background9#55.png-13:body21#47.png-15:pattern7#29.png",
     "edition": 40,
     "date": 1758112208816,
@@ -1042,7 +1042,7 @@
   {
     "name": "#41",
     "description": "Pixel Art NFT Collection",
-    "image": "41.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/41.png",
     "dna": "8:background9#55.png-10:body19#43.png-7:pattern16#56.png",
     "edition": 41,
     "date": 1758112208867,
@@ -1068,7 +1068,7 @@
   {
     "name": "#42",
     "description": "Pixel Art NFT Collection",
-    "image": "42.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/42.png",
     "dna": "7:background8#50.png-9:body18#41.png-11:pattern3#17.png",
     "edition": 42,
     "date": 1758112208925,
@@ -1094,7 +1094,7 @@
   {
     "name": "#43",
     "description": "Pixel Art NFT Collection",
-    "image": "43.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/43.png",
     "dna": "8:background9#55.png-17:body25#55.png-5:pattern14#50.png",
     "edition": 43,
     "date": 1758112208976,
@@ -1120,7 +1120,7 @@
   {
     "name": "#44",
     "description": "Pixel Art NFT Collection",
-    "image": "44.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/44.png",
     "dna": "0:background1#15.png-21:body29#63.png-4:pattern13#47.png",
     "edition": 44,
     "date": 1758112209030,
@@ -1146,7 +1146,7 @@
   {
     "name": "#45",
     "description": "Pixel Art NFT Collection",
-    "image": "45.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/45.png",
     "dna": "6:background7#45.png-9:body18#41.png-5:pattern14#50.png",
     "edition": 45,
     "date": 1758112209078,
@@ -1172,7 +1172,7 @@
   {
     "name": "#46",
     "description": "Pixel Art NFT Collection",
-    "image": "46.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/46.png",
     "dna": "7:background8#50.png-21:body29#63.png-4:pattern13#47.png",
     "edition": 46,
     "date": 1758112209134,
@@ -1198,7 +1198,7 @@
   {
     "name": "#47",
     "description": "Pixel Art NFT Collection",
-    "image": "47.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/47.png",
     "dna": "4:background5#35.png-15:body23#51.png-11:pattern3#17.png",
     "edition": 47,
     "date": 1758112209183,
@@ -1224,7 +1224,7 @@
   {
     "name": "#48",
     "description": "Pixel Art NFT Collection",
-    "image": "48.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/48.png",
     "dna": "6:background7#45.png-20:body28#61.png-8:pattern17#59.png",
     "edition": 48,
     "date": 1758112209246,
@@ -1250,7 +1250,7 @@
   {
     "name": "#49",
     "description": "Pixel Art NFT Collection",
-    "image": "49.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/49.png",
     "dna": "5:background6#40.png-15:body23#51.png-9:pattern18#62.png",
     "edition": 49,
     "date": 1758112209308,
@@ -1276,7 +1276,7 @@
   {
     "name": "#50",
     "description": "Pixel Art NFT Collection",
-    "image": "50.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/50.png",
     "dna": "4:background5#35.png-7:body16#37.png-15:pattern7#29.png",
     "edition": 50,
     "date": 1758112209359,
@@ -1302,7 +1302,7 @@
   {
     "name": "#51",
     "description": "Pixel Art NFT Collection",
-    "image": "51.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/51.png",
     "dna": "3:background4#30.png-13:body21#47.png-4:pattern13#47.png",
     "edition": 51,
     "date": 1758112209423,
@@ -1328,7 +1328,7 @@
   {
     "name": "#52",
     "description": "Pixel Art NFT Collection",
-    "image": "52.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/52.png",
     "dna": "5:background6#40.png-25:body5#15.png-7:pattern16#56.png",
     "edition": 52,
     "date": 1758112209473,
@@ -1354,7 +1354,7 @@
   {
     "name": "#53",
     "description": "Pixel Art NFT Collection",
-    "image": "53.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/53.png",
     "dna": "2:background3#25.png-13:body21#47.png-3:pattern12#44.png",
     "edition": 53,
     "date": 1758112209522,
@@ -1380,7 +1380,7 @@
   {
     "name": "#54",
     "description": "Pixel Art NFT Collection",
-    "image": "54.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/54.png",
     "dna": "8:background9#55.png-9:body18#41.png-1:pattern10#38.png",
     "edition": 54,
     "date": 1758112209577,
@@ -1406,7 +1406,7 @@
   {
     "name": "#55",
     "description": "Pixel Art NFT Collection",
-    "image": "55.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/55.png",
     "dna": "5:background6#40.png-8:body17#39.png-8:pattern17#59.png",
     "edition": 55,
     "date": 1758112209625,
@@ -1432,7 +1432,7 @@
   {
     "name": "#56",
     "description": "Pixel Art NFT Collection",
-    "image": "56.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/56.png",
     "dna": "7:background8#50.png-9:body18#41.png-6:pattern15#53.png",
     "edition": 56,
     "date": 1758112209674,
@@ -1458,7 +1458,7 @@
   {
     "name": "#57",
     "description": "Pixel Art NFT Collection",
-    "image": "57.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/57.png",
     "dna": "5:background6#40.png-23:body30#65.png-4:pattern13#47.png",
     "edition": 57,
     "date": 1758112209738,
@@ -1484,7 +1484,7 @@
   {
     "name": "#58",
     "description": "Pixel Art NFT Collection",
-    "image": "58.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/58.png",
     "dna": "5:background6#40.png-13:body21#47.png-4:pattern13#47.png",
     "edition": 58,
     "date": 1758112209789,
@@ -1510,7 +1510,7 @@
   {
     "name": "#59",
     "description": "Pixel Art NFT Collection",
-    "image": "59.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/59.png",
     "dna": "2:background3#25.png-15:body23#51.png-9:pattern18#62.png",
     "edition": 59,
     "date": 1758112209839,
@@ -1536,7 +1536,7 @@
   {
     "name": "#60",
     "description": "Pixel Art NFT Collection",
-    "image": "60.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/60.png",
     "dna": "5:background6#40.png-3:body12#29.png-7:pattern16#56.png",
     "edition": 60,
     "date": 1758112209895,
@@ -1562,7 +1562,7 @@
   {
     "name": "#61",
     "description": "Pixel Art NFT Collection",
-    "image": "61.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/61.png",
     "dna": "8:background9#55.png-19:body27#59.png-5:pattern14#50.png",
     "edition": 61,
     "date": 1758112209949,
@@ -1588,7 +1588,7 @@
   {
     "name": "#62",
     "description": "Pixel Art NFT Collection",
-    "image": "62.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/62.png",
     "dna": "2:background3#25.png-14:body22#49.png-5:pattern14#50.png",
     "edition": 62,
     "date": 1758112209997,
@@ -1614,7 +1614,7 @@
   {
     "name": "#63",
     "description": "Pixel Art NFT Collection",
-    "image": "63.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/63.png",
     "dna": "0:background1#15.png-21:body29#63.png-14:pattern6#26.png",
     "edition": 63,
     "date": 1758112210046,
@@ -1640,7 +1640,7 @@
   {
     "name": "#64",
     "description": "Pixel Art NFT Collection",
-    "image": "64.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/64.png",
     "dna": "4:background5#35.png-21:body29#63.png-5:pattern14#50.png",
     "edition": 64,
     "date": 1758112210096,
@@ -1666,7 +1666,7 @@
   {
     "name": "#65",
     "description": "Pixel Art NFT Collection",
-    "image": "65.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/65.png",
     "dna": "3:background4#30.png-3:body12#29.png-1:pattern10#38.png",
     "edition": 65,
     "date": 1758112210146,
@@ -1692,7 +1692,7 @@
   {
     "name": "#66",
     "description": "Pixel Art NFT Collection",
-    "image": "66.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/66.png",
     "dna": "8:background9#55.png-29:body9#23.png-8:pattern17#59.png",
     "edition": 66,
     "date": 1758112210203,
@@ -1718,7 +1718,7 @@
   {
     "name": "#67",
     "description": "Pixel Art NFT Collection",
-    "image": "67.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/67.png",
     "dna": "7:background8#50.png-10:body19#43.png-16:pattern8#32.png",
     "edition": 67,
     "date": 1758112210252,
@@ -1744,7 +1744,7 @@
   {
     "name": "#68",
     "description": "Pixel Art NFT Collection",
-    "image": "68.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/68.png",
     "dna": "5:background6#40.png-21:body29#63.png-11:pattern3#17.png",
     "edition": 68,
     "date": 1758112210302,
@@ -1770,7 +1770,7 @@
   {
     "name": "#69",
     "description": "Pixel Art NFT Collection",
-    "image": "69.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/69.png",
     "dna": "5:background6#40.png-9:body18#41.png-8:pattern17#59.png",
     "edition": 69,
     "date": 1758112210349,
@@ -1796,7 +1796,7 @@
   {
     "name": "#70",
     "description": "Pixel Art NFT Collection",
-    "image": "70.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/70.png",
     "dna": "7:background8#50.png-11:body2#9.png-16:pattern8#32.png",
     "edition": 70,
     "date": 1758112210399,
@@ -1822,7 +1822,7 @@
   {
     "name": "#71",
     "description": "Pixel Art NFT Collection",
-    "image": "71.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/71.png",
     "dna": "5:background6#40.png-17:body25#55.png-8:pattern17#59.png",
     "edition": 71,
     "date": 1758112210446,
@@ -1848,7 +1848,7 @@
   {
     "name": "#72",
     "description": "Pixel Art NFT Collection",
-    "image": "72.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/72.png",
     "dna": "6:background7#45.png-8:body17#39.png-17:pattern9#35.png",
     "edition": 72,
     "date": 1758112210500,
@@ -1874,7 +1874,7 @@
   {
     "name": "#73",
     "description": "Pixel Art NFT Collection",
-    "image": "73.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/73.png",
     "dna": "7:background8#50.png-4:body13#31.png-7:pattern16#56.png",
     "edition": 73,
     "date": 1758112210550,
@@ -1900,7 +1900,7 @@
   {
     "name": "#74",
     "description": "Pixel Art NFT Collection",
-    "image": "74.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/74.png",
     "dna": "7:background8#50.png-17:body25#55.png-16:pattern8#32.png",
     "edition": 74,
     "date": 1758112210599,
@@ -1926,7 +1926,7 @@
   {
     "name": "#75",
     "description": "Pixel Art NFT Collection",
-    "image": "75.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/75.png",
     "dna": "7:background8#50.png-14:body22#49.png-17:pattern9#35.png",
     "edition": 75,
     "date": 1758112210648,
@@ -1952,7 +1952,7 @@
   {
     "name": "#76",
     "description": "Pixel Art NFT Collection",
-    "image": "76.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/76.png",
     "dna": "7:background8#50.png-11:body2#9.png-11:pattern3#17.png",
     "edition": 76,
     "date": 1758112210696,
@@ -1978,7 +1978,7 @@
   {
     "name": "#77",
     "description": "Pixel Art NFT Collection",
-    "image": "77.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/77.png",
     "dna": "6:background7#45.png-16:body24#53.png-9:pattern18#62.png",
     "edition": 77,
     "date": 1758112210752,
@@ -2004,7 +2004,7 @@
   {
     "name": "#78",
     "description": "Pixel Art NFT Collection",
-    "image": "78.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/78.png",
     "dna": "7:background8#50.png-23:body30#65.png-1:pattern10#38.png",
     "edition": 78,
     "date": 1758112210847,
@@ -2030,7 +2030,7 @@
   {
     "name": "#79",
     "description": "Pixel Art NFT Collection",
-    "image": "79.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/79.png",
     "dna": "8:background9#55.png-14:body22#49.png-4:pattern13#47.png",
     "edition": 79,
     "date": 1758112210901,
@@ -2056,7 +2056,7 @@
   {
     "name": "#80",
     "description": "Pixel Art NFT Collection",
-    "image": "80.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/80.png",
     "dna": "7:background8#50.png-14:body22#49.png-11:pattern3#17.png",
     "edition": 80,
     "date": 1758112210957,
@@ -2082,7 +2082,7 @@
   {
     "name": "#81",
     "description": "Pixel Art NFT Collection",
-    "image": "81.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/81.png",
     "dna": "8:background9#55.png-13:body21#47.png-9:pattern18#62.png",
     "edition": 81,
     "date": 1758112211004,
@@ -2108,7 +2108,7 @@
   {
     "name": "#82",
     "description": "Pixel Art NFT Collection",
-    "image": "82.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/82.png",
     "dna": "5:background6#40.png-24:body4#13.png-3:pattern12#44.png",
     "edition": 82,
     "date": 1758112211051,
@@ -2134,7 +2134,7 @@
   {
     "name": "#83",
     "description": "Pixel Art NFT Collection",
-    "image": "83.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/83.png",
     "dna": "3:background4#30.png-4:body13#31.png-4:pattern13#47.png",
     "edition": 83,
     "date": 1758112211099,
@@ -2160,7 +2160,7 @@
   {
     "name": "#84",
     "description": "Pixel Art NFT Collection",
-    "image": "84.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/84.png",
     "dna": "3:background4#30.png-22:body3#11.png-6:pattern15#53.png",
     "edition": 84,
     "date": 1758112211151,
@@ -2186,7 +2186,7 @@
   {
     "name": "#85",
     "description": "Pixel Art NFT Collection",
-    "image": "85.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/85.png",
     "dna": "8:background9#55.png-19:body27#59.png-1:pattern10#38.png",
     "edition": 85,
     "date": 1758112211205,
@@ -2212,7 +2212,7 @@
   {
     "name": "#86",
     "description": "Pixel Art NFT Collection",
-    "image": "86.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/86.png",
     "dna": "3:background4#30.png-10:body19#43.png-4:pattern13#47.png",
     "edition": 86,
     "date": 1758112211253,
@@ -2238,7 +2238,7 @@
   {
     "name": "#87",
     "description": "Pixel Art NFT Collection",
-    "image": "87.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/87.png",
     "dna": "7:background8#50.png-25:body5#15.png-6:pattern15#53.png",
     "edition": 87,
     "date": 1758112211303,
@@ -2264,7 +2264,7 @@
   {
     "name": "#88",
     "description": "Pixel Art NFT Collection",
-    "image": "88.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/88.png",
     "dna": "6:background7#45.png-18:body26#57.png-16:pattern8#32.png",
     "edition": 88,
     "date": 1758112211351,
@@ -2290,7 +2290,7 @@
   {
     "name": "#89",
     "description": "Pixel Art NFT Collection",
-    "image": "89.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/89.png",
     "dna": "3:background4#30.png-20:body28#61.png-8:pattern17#59.png",
     "edition": 89,
     "date": 1758112211401,
@@ -2316,7 +2316,7 @@
   {
     "name": "#90",
     "description": "Pixel Art NFT Collection",
-    "image": "90.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/90.png",
     "dna": "7:background8#50.png-3:body12#29.png-4:pattern13#47.png",
     "edition": 90,
     "date": 1758112211455,
@@ -2342,7 +2342,7 @@
   {
     "name": "#91",
     "description": "Pixel Art NFT Collection",
-    "image": "91.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/91.png",
     "dna": "4:background5#35.png-5:body14#33.png-16:pattern8#32.png",
     "edition": 91,
     "date": 1758112211509,
@@ -2368,7 +2368,7 @@
   {
     "name": "#92",
     "description": "Pixel Art NFT Collection",
-    "image": "92.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/92.png",
     "dna": "8:background9#55.png-20:body28#61.png-6:pattern15#53.png",
     "edition": 92,
     "date": 1758112211562,
@@ -2394,7 +2394,7 @@
   {
     "name": "#93",
     "description": "Pixel Art NFT Collection",
-    "image": "93.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/93.png",
     "dna": "5:background6#40.png-0:body1#7.png-13:pattern5#23.png",
     "edition": 93,
     "date": 1758112211610,
@@ -2420,7 +2420,7 @@
   {
     "name": "#94",
     "description": "Pixel Art NFT Collection",
-    "image": "94.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/94.png",
     "dna": "8:background9#55.png-25:body5#15.png-7:pattern16#56.png",
     "edition": 94,
     "date": 1758112211657,
@@ -2446,7 +2446,7 @@
   {
     "name": "#95",
     "description": "Pixel Art NFT Collection",
-    "image": "95.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/95.png",
     "dna": "8:background9#55.png-23:body30#65.png-14:pattern6#26.png",
     "edition": 95,
     "date": 1758112211718,
@@ -2472,7 +2472,7 @@
   {
     "name": "#96",
     "description": "Pixel Art NFT Collection",
-    "image": "96.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/96.png",
     "dna": "4:background5#35.png-16:body24#53.png-14:pattern6#26.png",
     "edition": 96,
     "date": 1758112211773,
@@ -2498,7 +2498,7 @@
   {
     "name": "#97",
     "description": "Pixel Art NFT Collection",
-    "image": "97.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/97.png",
     "dna": "6:background7#45.png-7:body16#37.png-17:pattern9#35.png",
     "edition": 97,
     "date": 1758112211821,
@@ -2524,7 +2524,7 @@
   {
     "name": "#98",
     "description": "Pixel Art NFT Collection",
-    "image": "98.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/98.png",
     "dna": "4:background5#35.png-6:body15#35.png-17:pattern9#35.png",
     "edition": 98,
     "date": 1758112211870,
@@ -2550,7 +2550,7 @@
   {
     "name": "#99",
     "description": "Pixel Art NFT Collection",
-    "image": "99.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/99.png",
     "dna": "6:background7#45.png-20:body28#61.png-6:pattern15#53.png",
     "edition": 99,
     "date": 1758112211928,
@@ -2576,7 +2576,7 @@
   {
     "name": "#100",
     "description": "Pixel Art NFT Collection",
-    "image": "100.png",
+    "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/100.png",
     "dna": "7:background8#50.png-21:body29#63.png-5:pattern14#50.png",
     "edition": 100,
     "date": 1758112211991,

--- a/nftbuild/metadata/1.json
+++ b/nftbuild/metadata/1.json
@@ -1,0 +1,26 @@
+{
+  "name": "#1",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/1.png",
+  "dna": "6:background7#45.png-26:body6#17.png-4:pattern13#47.png",
+  "edition": 1,
+  "date": 1758112206617,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "17"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/10.json
+++ b/nftbuild/metadata/10.json
@@ -1,0 +1,26 @@
+{
+  "name": "#10",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/10.png",
+  "dna": "6:background7#45.png-18:body26#57.png-15:pattern7#29.png",
+  "edition": 10,
+  "date": 1758112207125,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "57"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "29"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/100.json
+++ b/nftbuild/metadata/100.json
@@ -1,0 +1,26 @@
+{
+  "name": "#100",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/100.png",
+  "dna": "7:background8#50.png-21:body29#63.png-5:pattern14#50.png",
+  "edition": 100,
+  "date": 1758112211991,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "63"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "50"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/11.json
+++ b/nftbuild/metadata/11.json
@@ -1,0 +1,26 @@
+{
+  "name": "#11",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/11.png",
+  "dna": "1:background2#20.png-5:body14#33.png-6:pattern15#53.png",
+  "edition": 11,
+  "date": 1758112207178,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "20"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "33"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/12.json
+++ b/nftbuild/metadata/12.json
@@ -1,0 +1,26 @@
+{
+  "name": "#12",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/12.png",
+  "dna": "3:background4#30.png-23:body30#65.png-6:pattern15#53.png",
+  "edition": 12,
+  "date": 1758112207249,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "65"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/13.json
+++ b/nftbuild/metadata/13.json
@@ -1,0 +1,26 @@
+{
+  "name": "#13",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/13.png",
+  "dna": "4:background5#35.png-14:body22#49.png-14:pattern6#26.png",
+  "edition": 13,
+  "date": 1758112207299,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "49"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "26"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/14.json
+++ b/nftbuild/metadata/14.json
@@ -1,0 +1,26 @@
+{
+  "name": "#14",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/14.png",
+  "dna": "5:background6#40.png-15:body23#51.png-0:pattern1#11.png",
+  "edition": 14,
+  "date": 1758112207350,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "51"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "11"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/15.json
+++ b/nftbuild/metadata/15.json
@@ -1,0 +1,26 @@
+{
+  "name": "#15",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/15.png",
+  "dna": "5:background6#40.png-19:body27#59.png-2:pattern11#41.png",
+  "edition": 15,
+  "date": 1758112207406,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "59"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "41"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/16.json
+++ b/nftbuild/metadata/16.json
@@ -1,0 +1,26 @@
+{
+  "name": "#16",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/16.png",
+  "dna": "3:background4#30.png-13:body21#47.png-14:pattern6#26.png",
+  "edition": 16,
+  "date": 1758112207455,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "47"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "26"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/17.json
+++ b/nftbuild/metadata/17.json
@@ -1,0 +1,26 @@
+{
+  "name": "#17",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/17.png",
+  "dna": "4:background5#35.png-18:body26#57.png-14:pattern6#26.png",
+  "edition": 17,
+  "date": 1758112207505,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "57"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "26"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/18.json
+++ b/nftbuild/metadata/18.json
@@ -1,0 +1,26 @@
+{
+  "name": "#18",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/18.png",
+  "dna": "5:background6#40.png-18:body26#57.png-2:pattern11#41.png",
+  "edition": 18,
+  "date": 1758112207561,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "57"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "41"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/19.json
+++ b/nftbuild/metadata/19.json
@@ -1,0 +1,26 @@
+{
+  "name": "#19",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/19.png",
+  "dna": "3:background4#30.png-20:body28#61.png-9:pattern18#62.png",
+  "edition": 19,
+  "date": 1758112207614,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "61"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "62"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/2.json
+++ b/nftbuild/metadata/2.json
@@ -1,0 +1,26 @@
+{
+  "name": "#2",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/2.png",
+  "dna": "6:background7#45.png-10:body19#43.png-7:pattern16#56.png",
+  "edition": 2,
+  "date": 1758112206693,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "43"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "56"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/20.json
+++ b/nftbuild/metadata/20.json
@@ -1,0 +1,26 @@
+{
+  "name": "#20",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/20.png",
+  "dna": "2:background3#25.png-21:body29#63.png-15:pattern7#29.png",
+  "edition": 20,
+  "date": 1758112207666,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "25"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "63"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "29"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/21.json
+++ b/nftbuild/metadata/21.json
@@ -1,0 +1,26 @@
+{
+  "name": "#21",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/21.png",
+  "dna": "7:background8#50.png-22:body3#11.png-1:pattern10#38.png",
+  "edition": 21,
+  "date": 1758112207718,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "11"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "38"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/22.json
+++ b/nftbuild/metadata/22.json
@@ -1,0 +1,26 @@
+{
+  "name": "#22",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/22.png",
+  "dna": "0:background1#15.png-9:body18#41.png-6:pattern15#53.png",
+  "edition": 22,
+  "date": 1758112207771,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "15"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "41"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/23.json
+++ b/nftbuild/metadata/23.json
@@ -1,0 +1,26 @@
+{
+  "name": "#23",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/23.png",
+  "dna": "7:background8#50.png-8:body17#39.png-9:pattern18#62.png",
+  "edition": 23,
+  "date": 1758112207828,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "39"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "62"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/24.json
+++ b/nftbuild/metadata/24.json
@@ -1,0 +1,26 @@
+{
+  "name": "#24",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/24.png",
+  "dna": "4:background5#35.png-23:body30#65.png-3:pattern12#44.png",
+  "edition": 24,
+  "date": 1758112207955,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "65"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "44"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/25.json
+++ b/nftbuild/metadata/25.json
@@ -1,0 +1,26 @@
+{
+  "name": "#25",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/25.png",
+  "dna": "4:background5#35.png-3:body12#29.png-8:pattern17#59.png",
+  "edition": 25,
+  "date": 1758112208016,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "29"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "59"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/26.json
+++ b/nftbuild/metadata/26.json
@@ -1,0 +1,26 @@
+{
+  "name": "#26",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/26.png",
+  "dna": "0:background1#15.png-20:body28#61.png-3:pattern12#44.png",
+  "edition": 26,
+  "date": 1758112208073,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "15"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "61"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "44"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/27.json
+++ b/nftbuild/metadata/27.json
@@ -1,0 +1,26 @@
+{
+  "name": "#27",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/27.png",
+  "dna": "3:background4#30.png-14:body22#49.png-3:pattern12#44.png",
+  "edition": 27,
+  "date": 1758112208125,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "49"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "44"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/28.json
+++ b/nftbuild/metadata/28.json
@@ -1,0 +1,26 @@
+{
+  "name": "#28",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/28.png",
+  "dna": "4:background5#35.png-21:body29#63.png-17:pattern9#35.png",
+  "edition": 28,
+  "date": 1758112208176,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "63"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "35"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/29.json
+++ b/nftbuild/metadata/29.json
@@ -1,0 +1,26 @@
+{
+  "name": "#29",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/29.png",
+  "dna": "4:background5#35.png-7:body16#37.png-9:pattern18#62.png",
+  "edition": 29,
+  "date": 1758112208227,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "37"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "62"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/3.json
+++ b/nftbuild/metadata/3.json
@@ -1,0 +1,26 @@
+{
+  "name": "#3",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/3.png",
+  "dna": "3:background4#30.png-1:body10#25.png-7:pattern16#56.png",
+  "edition": 3,
+  "date": 1758112206752,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "25"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "56"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/30.json
+++ b/nftbuild/metadata/30.json
@@ -1,0 +1,26 @@
+{
+  "name": "#30",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/30.png",
+  "dna": "4:background5#35.png-6:body15#35.png-0:pattern1#11.png",
+  "edition": 30,
+  "date": 1758112208285,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "11"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/31.json
+++ b/nftbuild/metadata/31.json
@@ -1,0 +1,26 @@
+{
+  "name": "#31",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/31.png",
+  "dna": "4:background5#35.png-24:body4#13.png-2:pattern11#41.png",
+  "edition": 31,
+  "date": 1758112208337,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "13"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "41"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/32.json
+++ b/nftbuild/metadata/32.json
@@ -1,0 +1,26 @@
+{
+  "name": "#32",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/32.png",
+  "dna": "5:background6#40.png-25:body5#15.png-14:pattern6#26.png",
+  "edition": 32,
+  "date": 1758112208392,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "15"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "26"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/33.json
+++ b/nftbuild/metadata/33.json
@@ -1,0 +1,26 @@
+{
+  "name": "#33",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/33.png",
+  "dna": "5:background6#40.png-4:body13#31.png-13:pattern5#23.png",
+  "edition": 33,
+  "date": 1758112208444,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "31"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "23"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/34.json
+++ b/nftbuild/metadata/34.json
@@ -1,0 +1,26 @@
+{
+  "name": "#34",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/34.png",
+  "dna": "6:background7#45.png-20:body28#61.png-17:pattern9#35.png",
+  "edition": 34,
+  "date": 1758112208500,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "61"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "35"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/35.json
+++ b/nftbuild/metadata/35.json
@@ -1,0 +1,26 @@
+{
+  "name": "#35",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/35.png",
+  "dna": "4:background5#35.png-13:body21#47.png-15:pattern7#29.png",
+  "edition": 35,
+  "date": 1758112208550,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "47"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "29"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/36.json
+++ b/nftbuild/metadata/36.json
@@ -1,0 +1,26 @@
+{
+  "name": "#36",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/36.png",
+  "dna": "3:background4#30.png-8:body17#39.png-11:pattern3#17.png",
+  "edition": 36,
+  "date": 1758112208609,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "39"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "17"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/37.json
+++ b/nftbuild/metadata/37.json
@@ -1,0 +1,26 @@
+{
+  "name": "#37",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/37.png",
+  "dna": "6:background7#45.png-19:body27#59.png-4:pattern13#47.png",
+  "edition": 37,
+  "date": 1758112208664,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "59"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/38.json
+++ b/nftbuild/metadata/38.json
@@ -1,0 +1,26 @@
+{
+  "name": "#38",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/38.png",
+  "dna": "7:background8#50.png-6:body15#35.png-3:pattern12#44.png",
+  "edition": 38,
+  "date": 1758112208715,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "44"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/39.json
+++ b/nftbuild/metadata/39.json
@@ -1,0 +1,26 @@
+{
+  "name": "#39",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/39.png",
+  "dna": "7:background8#50.png-7:body16#37.png-14:pattern6#26.png",
+  "edition": 39,
+  "date": 1758112208766,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "37"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "26"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/4.json
+++ b/nftbuild/metadata/4.json
@@ -1,0 +1,26 @@
+{
+  "name": "#4",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/4.png",
+  "dna": "2:background3#25.png-10:body19#43.png-8:pattern17#59.png",
+  "edition": 4,
+  "date": 1758112206803,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "25"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "43"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "59"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/40.json
+++ b/nftbuild/metadata/40.json
@@ -1,0 +1,26 @@
+{
+  "name": "#40",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/40.png",
+  "dna": "8:background9#55.png-13:body21#47.png-15:pattern7#29.png",
+  "edition": 40,
+  "date": 1758112208816,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "47"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "29"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/41.json
+++ b/nftbuild/metadata/41.json
@@ -1,0 +1,26 @@
+{
+  "name": "#41",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/41.png",
+  "dna": "8:background9#55.png-10:body19#43.png-7:pattern16#56.png",
+  "edition": 41,
+  "date": 1758112208867,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "43"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "56"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/42.json
+++ b/nftbuild/metadata/42.json
@@ -1,0 +1,26 @@
+{
+  "name": "#42",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/42.png",
+  "dna": "7:background8#50.png-9:body18#41.png-11:pattern3#17.png",
+  "edition": 42,
+  "date": 1758112208925,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "41"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "17"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/43.json
+++ b/nftbuild/metadata/43.json
@@ -1,0 +1,26 @@
+{
+  "name": "#43",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/43.png",
+  "dna": "8:background9#55.png-17:body25#55.png-5:pattern14#50.png",
+  "edition": 43,
+  "date": 1758112208976,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "50"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/44.json
+++ b/nftbuild/metadata/44.json
@@ -1,0 +1,26 @@
+{
+  "name": "#44",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/44.png",
+  "dna": "0:background1#15.png-21:body29#63.png-4:pattern13#47.png",
+  "edition": 44,
+  "date": 1758112209030,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "15"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "63"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/45.json
+++ b/nftbuild/metadata/45.json
@@ -1,0 +1,26 @@
+{
+  "name": "#45",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/45.png",
+  "dna": "6:background7#45.png-9:body18#41.png-5:pattern14#50.png",
+  "edition": 45,
+  "date": 1758112209078,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "41"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "50"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/46.json
+++ b/nftbuild/metadata/46.json
@@ -1,0 +1,26 @@
+{
+  "name": "#46",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/46.png",
+  "dna": "7:background8#50.png-21:body29#63.png-4:pattern13#47.png",
+  "edition": 46,
+  "date": 1758112209134,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "63"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/47.json
+++ b/nftbuild/metadata/47.json
@@ -1,0 +1,26 @@
+{
+  "name": "#47",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/47.png",
+  "dna": "4:background5#35.png-15:body23#51.png-11:pattern3#17.png",
+  "edition": 47,
+  "date": 1758112209183,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "51"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "17"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/48.json
+++ b/nftbuild/metadata/48.json
@@ -1,0 +1,26 @@
+{
+  "name": "#48",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/48.png",
+  "dna": "6:background7#45.png-20:body28#61.png-8:pattern17#59.png",
+  "edition": 48,
+  "date": 1758112209246,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "61"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "59"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/49.json
+++ b/nftbuild/metadata/49.json
@@ -1,0 +1,26 @@
+{
+  "name": "#49",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/49.png",
+  "dna": "5:background6#40.png-15:body23#51.png-9:pattern18#62.png",
+  "edition": 49,
+  "date": 1758112209308,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "51"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "62"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/5.json
+++ b/nftbuild/metadata/5.json
@@ -1,0 +1,26 @@
+{
+  "name": "#5",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/5.png",
+  "dna": "8:background9#55.png-7:body16#37.png-12:pattern4#20.png",
+  "edition": 5,
+  "date": 1758112206865,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "37"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "20"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/50.json
+++ b/nftbuild/metadata/50.json
@@ -1,0 +1,26 @@
+{
+  "name": "#50",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/50.png",
+  "dna": "4:background5#35.png-7:body16#37.png-15:pattern7#29.png",
+  "edition": 50,
+  "date": 1758112209359,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "37"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "29"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/51.json
+++ b/nftbuild/metadata/51.json
@@ -1,0 +1,26 @@
+{
+  "name": "#51",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/51.png",
+  "dna": "3:background4#30.png-13:body21#47.png-4:pattern13#47.png",
+  "edition": 51,
+  "date": 1758112209423,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "47"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/52.json
+++ b/nftbuild/metadata/52.json
@@ -1,0 +1,26 @@
+{
+  "name": "#52",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/52.png",
+  "dna": "5:background6#40.png-25:body5#15.png-7:pattern16#56.png",
+  "edition": 52,
+  "date": 1758112209473,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "15"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "56"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/53.json
+++ b/nftbuild/metadata/53.json
@@ -1,0 +1,26 @@
+{
+  "name": "#53",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/53.png",
+  "dna": "2:background3#25.png-13:body21#47.png-3:pattern12#44.png",
+  "edition": 53,
+  "date": 1758112209522,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "25"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "47"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "44"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/54.json
+++ b/nftbuild/metadata/54.json
@@ -1,0 +1,26 @@
+{
+  "name": "#54",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/54.png",
+  "dna": "8:background9#55.png-9:body18#41.png-1:pattern10#38.png",
+  "edition": 54,
+  "date": 1758112209577,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "41"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "38"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/55.json
+++ b/nftbuild/metadata/55.json
@@ -1,0 +1,26 @@
+{
+  "name": "#55",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/55.png",
+  "dna": "5:background6#40.png-8:body17#39.png-8:pattern17#59.png",
+  "edition": 55,
+  "date": 1758112209625,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "39"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "59"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/56.json
+++ b/nftbuild/metadata/56.json
@@ -1,0 +1,26 @@
+{
+  "name": "#56",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/56.png",
+  "dna": "7:background8#50.png-9:body18#41.png-6:pattern15#53.png",
+  "edition": 56,
+  "date": 1758112209674,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "41"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/57.json
+++ b/nftbuild/metadata/57.json
@@ -1,0 +1,26 @@
+{
+  "name": "#57",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/57.png",
+  "dna": "5:background6#40.png-23:body30#65.png-4:pattern13#47.png",
+  "edition": 57,
+  "date": 1758112209738,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "65"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/58.json
+++ b/nftbuild/metadata/58.json
@@ -1,0 +1,26 @@
+{
+  "name": "#58",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/58.png",
+  "dna": "5:background6#40.png-13:body21#47.png-4:pattern13#47.png",
+  "edition": 58,
+  "date": 1758112209789,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "47"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/59.json
+++ b/nftbuild/metadata/59.json
@@ -1,0 +1,26 @@
+{
+  "name": "#59",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/59.png",
+  "dna": "2:background3#25.png-15:body23#51.png-9:pattern18#62.png",
+  "edition": 59,
+  "date": 1758112209839,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "25"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "51"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "62"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/6.json
+++ b/nftbuild/metadata/6.json
@@ -1,0 +1,26 @@
+{
+  "name": "#6",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/6.png",
+  "dna": "8:background9#55.png-15:body23#51.png-7:pattern16#56.png",
+  "edition": 6,
+  "date": 1758112206922,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "51"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "56"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/60.json
+++ b/nftbuild/metadata/60.json
@@ -1,0 +1,26 @@
+{
+  "name": "#60",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/60.png",
+  "dna": "5:background6#40.png-3:body12#29.png-7:pattern16#56.png",
+  "edition": 60,
+  "date": 1758112209895,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "29"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "56"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/61.json
+++ b/nftbuild/metadata/61.json
@@ -1,0 +1,26 @@
+{
+  "name": "#61",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/61.png",
+  "dna": "8:background9#55.png-19:body27#59.png-5:pattern14#50.png",
+  "edition": 61,
+  "date": 1758112209949,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "59"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "50"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/62.json
+++ b/nftbuild/metadata/62.json
@@ -1,0 +1,26 @@
+{
+  "name": "#62",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/62.png",
+  "dna": "2:background3#25.png-14:body22#49.png-5:pattern14#50.png",
+  "edition": 62,
+  "date": 1758112209997,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "25"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "49"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "50"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/63.json
+++ b/nftbuild/metadata/63.json
@@ -1,0 +1,26 @@
+{
+  "name": "#63",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/63.png",
+  "dna": "0:background1#15.png-21:body29#63.png-14:pattern6#26.png",
+  "edition": 63,
+  "date": 1758112210046,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "15"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "63"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "26"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/64.json
+++ b/nftbuild/metadata/64.json
@@ -1,0 +1,26 @@
+{
+  "name": "#64",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/64.png",
+  "dna": "4:background5#35.png-21:body29#63.png-5:pattern14#50.png",
+  "edition": 64,
+  "date": 1758112210096,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "63"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "50"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/65.json
+++ b/nftbuild/metadata/65.json
@@ -1,0 +1,26 @@
+{
+  "name": "#65",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/65.png",
+  "dna": "3:background4#30.png-3:body12#29.png-1:pattern10#38.png",
+  "edition": 65,
+  "date": 1758112210146,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "29"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "38"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/66.json
+++ b/nftbuild/metadata/66.json
@@ -1,0 +1,26 @@
+{
+  "name": "#66",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/66.png",
+  "dna": "8:background9#55.png-29:body9#23.png-8:pattern17#59.png",
+  "edition": 66,
+  "date": 1758112210203,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "23"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "59"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/67.json
+++ b/nftbuild/metadata/67.json
@@ -1,0 +1,26 @@
+{
+  "name": "#67",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/67.png",
+  "dna": "7:background8#50.png-10:body19#43.png-16:pattern8#32.png",
+  "edition": 67,
+  "date": 1758112210252,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "43"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "32"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/68.json
+++ b/nftbuild/metadata/68.json
@@ -1,0 +1,26 @@
+{
+  "name": "#68",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/68.png",
+  "dna": "5:background6#40.png-21:body29#63.png-11:pattern3#17.png",
+  "edition": 68,
+  "date": 1758112210302,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "63"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "17"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/69.json
+++ b/nftbuild/metadata/69.json
@@ -1,0 +1,26 @@
+{
+  "name": "#69",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/69.png",
+  "dna": "5:background6#40.png-9:body18#41.png-8:pattern17#59.png",
+  "edition": 69,
+  "date": 1758112210349,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "41"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "59"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/7.json
+++ b/nftbuild/metadata/7.json
@@ -1,0 +1,26 @@
+{
+  "name": "#7",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/7.png",
+  "dna": "4:background5#35.png-16:body24#53.png-6:pattern15#53.png",
+  "edition": 7,
+  "date": 1758112206973,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "53"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/70.json
+++ b/nftbuild/metadata/70.json
@@ -1,0 +1,26 @@
+{
+  "name": "#70",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/70.png",
+  "dna": "7:background8#50.png-11:body2#9.png-16:pattern8#32.png",
+  "edition": 70,
+  "date": 1758112210399,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "9"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "32"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/71.json
+++ b/nftbuild/metadata/71.json
@@ -1,0 +1,26 @@
+{
+  "name": "#71",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/71.png",
+  "dna": "5:background6#40.png-17:body25#55.png-8:pattern17#59.png",
+  "edition": 71,
+  "date": 1758112210446,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "59"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/72.json
+++ b/nftbuild/metadata/72.json
@@ -1,0 +1,26 @@
+{
+  "name": "#72",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/72.png",
+  "dna": "6:background7#45.png-8:body17#39.png-17:pattern9#35.png",
+  "edition": 72,
+  "date": 1758112210500,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "39"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "35"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/73.json
+++ b/nftbuild/metadata/73.json
@@ -1,0 +1,26 @@
+{
+  "name": "#73",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/73.png",
+  "dna": "7:background8#50.png-4:body13#31.png-7:pattern16#56.png",
+  "edition": 73,
+  "date": 1758112210550,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "31"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "56"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/74.json
+++ b/nftbuild/metadata/74.json
@@ -1,0 +1,26 @@
+{
+  "name": "#74",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/74.png",
+  "dna": "7:background8#50.png-17:body25#55.png-16:pattern8#32.png",
+  "edition": 74,
+  "date": 1758112210599,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "32"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/75.json
+++ b/nftbuild/metadata/75.json
@@ -1,0 +1,26 @@
+{
+  "name": "#75",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/75.png",
+  "dna": "7:background8#50.png-14:body22#49.png-17:pattern9#35.png",
+  "edition": 75,
+  "date": 1758112210648,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "49"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "35"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/76.json
+++ b/nftbuild/metadata/76.json
@@ -1,0 +1,26 @@
+{
+  "name": "#76",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/76.png",
+  "dna": "7:background8#50.png-11:body2#9.png-11:pattern3#17.png",
+  "edition": 76,
+  "date": 1758112210696,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "9"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "17"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/77.json
+++ b/nftbuild/metadata/77.json
@@ -1,0 +1,26 @@
+{
+  "name": "#77",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/77.png",
+  "dna": "6:background7#45.png-16:body24#53.png-9:pattern18#62.png",
+  "edition": 77,
+  "date": 1758112210752,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "53"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "62"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/78.json
+++ b/nftbuild/metadata/78.json
@@ -1,0 +1,26 @@
+{
+  "name": "#78",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/78.png",
+  "dna": "7:background8#50.png-23:body30#65.png-1:pattern10#38.png",
+  "edition": 78,
+  "date": 1758112210847,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "65"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "38"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/79.json
+++ b/nftbuild/metadata/79.json
@@ -1,0 +1,26 @@
+{
+  "name": "#79",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/79.png",
+  "dna": "8:background9#55.png-14:body22#49.png-4:pattern13#47.png",
+  "edition": 79,
+  "date": 1758112210901,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "49"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/8.json
+++ b/nftbuild/metadata/8.json
@@ -1,0 +1,26 @@
+{
+  "name": "#8",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/8.png",
+  "dna": "8:background9#55.png-14:body22#49.png-16:pattern8#32.png",
+  "edition": 8,
+  "date": 1758112207023,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "49"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "32"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/80.json
+++ b/nftbuild/metadata/80.json
@@ -1,0 +1,26 @@
+{
+  "name": "#80",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/80.png",
+  "dna": "7:background8#50.png-14:body22#49.png-11:pattern3#17.png",
+  "edition": 80,
+  "date": 1758112210957,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "49"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "17"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/81.json
+++ b/nftbuild/metadata/81.json
@@ -1,0 +1,26 @@
+{
+  "name": "#81",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/81.png",
+  "dna": "8:background9#55.png-13:body21#47.png-9:pattern18#62.png",
+  "edition": 81,
+  "date": 1758112211004,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "47"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "62"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/82.json
+++ b/nftbuild/metadata/82.json
@@ -1,0 +1,26 @@
+{
+  "name": "#82",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/82.png",
+  "dna": "5:background6#40.png-24:body4#13.png-3:pattern12#44.png",
+  "edition": 82,
+  "date": 1758112211051,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "13"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "44"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/83.json
+++ b/nftbuild/metadata/83.json
@@ -1,0 +1,26 @@
+{
+  "name": "#83",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/83.png",
+  "dna": "3:background4#30.png-4:body13#31.png-4:pattern13#47.png",
+  "edition": 83,
+  "date": 1758112211099,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "31"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/84.json
+++ b/nftbuild/metadata/84.json
@@ -1,0 +1,26 @@
+{
+  "name": "#84",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/84.png",
+  "dna": "3:background4#30.png-22:body3#11.png-6:pattern15#53.png",
+  "edition": 84,
+  "date": 1758112211151,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "11"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/85.json
+++ b/nftbuild/metadata/85.json
@@ -1,0 +1,26 @@
+{
+  "name": "#85",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/85.png",
+  "dna": "8:background9#55.png-19:body27#59.png-1:pattern10#38.png",
+  "edition": 85,
+  "date": 1758112211205,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "59"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "38"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/86.json
+++ b/nftbuild/metadata/86.json
@@ -1,0 +1,26 @@
+{
+  "name": "#86",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/86.png",
+  "dna": "3:background4#30.png-10:body19#43.png-4:pattern13#47.png",
+  "edition": 86,
+  "date": 1758112211253,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "43"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/87.json
+++ b/nftbuild/metadata/87.json
@@ -1,0 +1,26 @@
+{
+  "name": "#87",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/87.png",
+  "dna": "7:background8#50.png-25:body5#15.png-6:pattern15#53.png",
+  "edition": 87,
+  "date": 1758112211303,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "15"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/88.json
+++ b/nftbuild/metadata/88.json
@@ -1,0 +1,26 @@
+{
+  "name": "#88",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/88.png",
+  "dna": "6:background7#45.png-18:body26#57.png-16:pattern8#32.png",
+  "edition": 88,
+  "date": 1758112211351,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "57"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "32"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/89.json
+++ b/nftbuild/metadata/89.json
@@ -1,0 +1,26 @@
+{
+  "name": "#89",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/89.png",
+  "dna": "3:background4#30.png-20:body28#61.png-8:pattern17#59.png",
+  "edition": 89,
+  "date": 1758112211401,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "61"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "59"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/9.json
+++ b/nftbuild/metadata/9.json
@@ -1,0 +1,26 @@
+{
+  "name": "#9",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/9.png",
+  "dna": "3:background4#30.png-28:body8#21.png-6:pattern15#53.png",
+  "edition": 9,
+  "date": 1758112207074,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "30"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "21"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/90.json
+++ b/nftbuild/metadata/90.json
@@ -1,0 +1,26 @@
+{
+  "name": "#90",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/90.png",
+  "dna": "7:background8#50.png-3:body12#29.png-4:pattern13#47.png",
+  "edition": 90,
+  "date": 1758112211455,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "50"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "29"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "47"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/91.json
+++ b/nftbuild/metadata/91.json
@@ -1,0 +1,26 @@
+{
+  "name": "#91",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/91.png",
+  "dna": "4:background5#35.png-5:body14#33.png-16:pattern8#32.png",
+  "edition": 91,
+  "date": 1758112211509,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "33"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "32"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/92.json
+++ b/nftbuild/metadata/92.json
@@ -1,0 +1,26 @@
+{
+  "name": "#92",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/92.png",
+  "dna": "8:background9#55.png-20:body28#61.png-6:pattern15#53.png",
+  "edition": 92,
+  "date": 1758112211562,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "61"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/93.json
+++ b/nftbuild/metadata/93.json
@@ -1,0 +1,26 @@
+{
+  "name": "#93",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/93.png",
+  "dna": "5:background6#40.png-0:body1#7.png-13:pattern5#23.png",
+  "edition": 93,
+  "date": 1758112211610,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "40"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "7"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "23"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/94.json
+++ b/nftbuild/metadata/94.json
@@ -1,0 +1,26 @@
+{
+  "name": "#94",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/94.png",
+  "dna": "8:background9#55.png-25:body5#15.png-7:pattern16#56.png",
+  "edition": 94,
+  "date": 1758112211657,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "b",
+      "rarity": "15"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "56"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/95.json
+++ b/nftbuild/metadata/95.json
@@ -1,0 +1,26 @@
+{
+  "name": "#95",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/95.png",
+  "dna": "8:background9#55.png-23:body30#65.png-14:pattern6#26.png",
+  "edition": 95,
+  "date": 1758112211718,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "55"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "65"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "26"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/96.json
+++ b/nftbuild/metadata/96.json
@@ -1,0 +1,26 @@
+{
+  "name": "#96",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/96.png",
+  "dna": "4:background5#35.png-16:body24#53.png-14:pattern6#26.png",
+  "edition": 96,
+  "date": 1758112211773,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "53"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "26"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/97.json
+++ b/nftbuild/metadata/97.json
@@ -1,0 +1,26 @@
+{
+  "name": "#97",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/97.png",
+  "dna": "6:background7#45.png-7:body16#37.png-17:pattern9#35.png",
+  "edition": 97,
+  "date": 1758112211821,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "37"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "35"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/98.json
+++ b/nftbuild/metadata/98.json
@@ -1,0 +1,26 @@
+{
+  "name": "#98",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/98.png",
+  "dna": "4:background5#35.png-6:body15#35.png-17:pattern9#35.png",
+  "edition": 98,
+  "date": 1758112211870,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "35"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patt",
+      "rarity": "35"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/nftbuild/metadata/99.json
+++ b/nftbuild/metadata/99.json
@@ -1,0 +1,26 @@
+{
+  "name": "#99",
+  "description": "Pixel Art NFT Collection",
+  "image": "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/images/99.png",
+  "dna": "6:background7#45.png-20:body28#61.png-6:pattern15#53.png",
+  "edition": 99,
+  "date": 1758112211928,
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "backgro",
+      "rarity": "45"
+    },
+    {
+      "trait_type": "BodyType",
+      "value": "bo",
+      "rarity": "61"
+    },
+    {
+      "trait_type": "Pattern",
+      "value": "patte",
+      "rarity": "53"
+    }
+  ],
+  "compiler": "Pixel Art NFT Generator"
+}

--- a/packages/hardhat/contracts/ButterflyPresale.sol
+++ b/packages/hardhat/contracts/ButterflyPresale.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+contract ButterflyPresale is ERC721Enumerable, Ownable, ReentrancyGuard {
+    struct Reservation {
+        address buyer;
+        uint96 pricePaid;
+        uint64 reservedAt;
+        bool fulfilled;
+    }
+
+    uint256 public immutable maxSupply;
+    uint256 public immutable mintPrice;
+    string private baseTokenURI;
+    address public treasury;
+    uint256 public totalReservations;
+
+    mapping(uint256 => Reservation) private _reservations;
+
+    event ReservationCreated(address indexed buyer, uint256 indexed tokenId, uint256 value);
+    event ReservationFulfilled(address indexed buyer, uint256 indexed tokenId);
+    event TreasuryUpdated(address indexed treasury);
+    event BaseURIUpdated(string newBaseURI);
+    event FundsWithdrawn(address indexed to, uint256 amount);
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        string memory baseTokenURI_,
+        uint256 maxSupply_,
+        uint256 mintPrice_,
+        address treasury_
+    ) ERC721(name_, symbol_) Ownable(msg.sender) {
+        require(maxSupply_ > 0, "Max supply zero");
+        require(treasury_ != address(0), "Treasury zero address");
+
+        baseTokenURI = baseTokenURI_;
+        maxSupply = maxSupply_;
+        mintPrice = mintPrice_;
+        treasury = treasury_;
+    }
+
+    function reserve(uint256 tokenId) external payable nonReentrant {
+        require(tokenId >= 1 && tokenId <= maxSupply, "Invalid tokenId");
+        require(msg.value == mintPrice, "Incorrect payment");
+        require(!_exists(tokenId), "Token already minted");
+
+        Reservation storage reservationData = _reservations[tokenId];
+        require(reservationData.buyer == address(0), "Token already reserved");
+
+        reservationData.buyer = msg.sender;
+        reservationData.pricePaid = uint96(msg.value);
+        reservationData.reservedAt = uint64(block.timestamp);
+
+        totalReservations += 1;
+
+        emit ReservationCreated(msg.sender, tokenId, msg.value);
+    }
+
+    function fulfillReservation(uint256 tokenId) external onlyOwner nonReentrant {
+        Reservation storage reservationData = _reservations[tokenId];
+        address buyer = reservationData.buyer;
+
+        require(buyer != address(0), "Reservation missing");
+        require(!reservationData.fulfilled, "Already fulfilled");
+        require(!_exists(tokenId), "Token already minted");
+        require(totalSupply() < maxSupply, "Max supply reached");
+
+        reservationData.fulfilled = true;
+        _safeMint(buyer, tokenId);
+
+        emit ReservationFulfilled(buyer, tokenId);
+    }
+
+    function reservation(uint256 tokenId) external view returns (Reservation memory) {
+        return _reservations[tokenId];
+    }
+
+    function isReserved(uint256 tokenId) external view returns (bool) {
+        return _reservations[tokenId].buyer != address(0);
+    }
+
+    function isFulfilled(uint256 tokenId) external view returns (bool) {
+        return _reservations[tokenId].fulfilled;
+    }
+
+    function setBaseTokenURI(string calldata newBaseTokenURI) external onlyOwner {
+        baseTokenURI = newBaseTokenURI;
+        emit BaseURIUpdated(newBaseTokenURI);
+    }
+
+    function setTreasury(address newTreasury) external onlyOwner {
+        require(newTreasury != address(0), "Treasury zero address");
+        treasury = newTreasury;
+        emit TreasuryUpdated(newTreasury);
+    }
+
+    function withdraw(address payable recipient) external onlyOwner nonReentrant {
+        address payable to = recipient;
+        if (to == address(0)) {
+            to = payable(treasury);
+        }
+
+        require(to != address(0), "Recipient zero address");
+
+        uint256 balance = address(this).balance;
+        require(balance > 0, "No funds to withdraw");
+
+        (bool success, ) = to.call{value: balance}("");
+        require(success, "Withdraw failed");
+
+        emit FundsWithdrawn(to, balance);
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return baseTokenURI;
+    }
+}

--- a/packages/hardhat/deploy/00_deploy_your_contract.ts
+++ b/packages/hardhat/deploy/00_deploy_your_contract.ts
@@ -1,44 +1,28 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
-import { Contract } from "ethers";
 
-/**
- * Deploys a contract named "YourContract" using the deployer account and
- * constructor arguments set to the deployer address
- *
- * @param hre HardhatRuntimeEnvironment object.
- */
-const deployYourContract: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  /*
-    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+const METADATA_BASE_URI = "ipfs://bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/metadata/";
+const COLLECTION_NAME = "Butterfly Presale";
+const COLLECTION_SYMBOL = "BFLY";
+const MAX_SUPPLY = 100n;
+const MINT_PRICE_WEI = 10_000_000_000_000_000n; // 0.01 ether
 
-    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
-    should have sufficient balance to pay for the gas fees for contract creation.
-
-    You can generate a random account with `yarn generate` or `yarn account:import` to import your
-    existing PK which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED in the .env file (then used on hardhat.config.ts)
-    You can run the `yarn account` command to check your balance in every network.
-  */
+const deployButterflyPresale: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
+  const { deploy, log } = hre.deployments;
 
-  await deploy("YourContract", {
+  log("\n🚀 Deploying ButterflyPresale...");
+
+  await deploy("ButterflyPresale", {
     from: deployer,
-    // Contract constructor arguments
-    args: [deployer],
+    args: [COLLECTION_NAME, COLLECTION_SYMBOL, METADATA_BASE_URI, MAX_SUPPLY, MINT_PRICE_WEI, deployer],
     log: true,
-    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
-    // automatically mining the contract deployment transaction. There is no effect on live networks.
     autoMine: true,
   });
 
-  // Get the deployed contract to interact with it after deploying.
-  const yourContract = await hre.ethers.getContract<Contract>("YourContract", deployer);
-  console.log("👋 Initial greeting:", await yourContract.greeting());
+  log("✅ ButterflyPresale deployed");
 };
 
-export default deployYourContract;
+deployButterflyPresale.tags = ["ButterflyPresale"];
 
-// Tags are useful if you have multiple deploy files and only want to run one of them.
-// e.g. yarn deploy --tags YourContract
-deployYourContract.tags = ["YourContract"];
+export default deployButterflyPresale;

--- a/packages/nextjs/app/nft/presale/page.tsx
+++ b/packages/nextjs/app/nft/presale/page.tsx
@@ -8,7 +8,13 @@ import { formatEther } from "viem";
 import { useAccount } from "wagmi";
 import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 
-const TOKEN_IDS = [1, 2, 3, 4, 5] as const;
+const PRESALE_ITEMS = [
+  { tokenId: 1, label: "001", backgroundColor: "#c8860d" },
+  { tokenId: 2, label: "002", backgroundColor: "#4c6ef5" },
+  { tokenId: 3, label: "003", backgroundColor: "#66d9ef" },
+  { tokenId: 4, label: "004", backgroundColor: "#20ff6d" },
+  { tokenId: 5, label: "005", backgroundColor: "#ff8787" },
+] as const;
 const COLLECTION_CID = "bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u";
 const IPFS_GATEWAY = "https://ipfs.io/ipfs";
 const METADATA_PATH_CANDIDATES = [
@@ -27,18 +33,10 @@ type ReservationInfo = {
 
 type NftMetadata = {
   name?: string;
-  description?: string;
   image?: string;
 };
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
-
-const formatAddress = (value: Address | undefined) => {
-  if (!value || value === ZERO_ADDRESS) {
-    return "";
-  }
-  return `${value.slice(0, 6)}…${value.slice(-4)}`;
-};
 
 const ipfsToHttp = (uri?: string) => {
   if (!uri) return undefined;
@@ -53,18 +51,13 @@ export default function PresalePage() {
     functionName: "mintPrice",
   });
 
-  const formattedMintPrice = mintPrice ? formatEther(mintPrice) : undefined;
-
   return (
     <div className="min-h-screen bg-[#05060A] pb-24">
       <ScreenHeader title="Presale" />
       <div className="px-4 py-6">
         <div className="mx-auto max-w-md space-y-4">
-          <p className="text-center text-sm text-[#cbd5f5]">
-            Mint price: {formattedMintPrice ? `${formattedMintPrice} ETH` : "Loading…"}
-          </p>
-          {TOKEN_IDS.map(tokenId => (
-            <PresaleItemCard key={tokenId} tokenId={tokenId} isConnected={isConnected} mintPrice={mintPrice} />
+          {PRESALE_ITEMS.map(item => (
+            <PresaleItemCard key={item.tokenId} item={item} isConnected={isConnected} mintPrice={mintPrice} />
           ))}
         </div>
       </div>
@@ -73,26 +66,19 @@ export default function PresalePage() {
 }
 
 type PresaleItemCardProps = {
-  tokenId: number;
+  item: (typeof PRESALE_ITEMS)[number];
   isConnected: boolean;
   mintPrice: bigint | undefined;
 };
 
-function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardProps) {
+function PresaleItemCard({ item, isConnected, mintPrice }: PresaleItemCardProps) {
   const [metadata, setMetadata] = useState<NftMetadata | null>(null);
-  const [isLoadingMetadata, setIsLoadingMetadata] = useState(true);
 
-  const tokenIdBigInt = useMemo(() => BigInt(tokenId), [tokenId]);
+  const tokenIdBigInt = useMemo(() => BigInt(item.tokenId), [item.tokenId]);
 
   const { data: reservationData } = useScaffoldReadContract({
     contractName: "ButterflyPresale",
     functionName: "reservation",
-    args: [tokenIdBigInt],
-  });
-
-  const { data: isFulfilled } = useScaffoldReadContract({
-    contractName: "ButterflyPresale",
-    functionName: "isFulfilled",
     args: [tokenIdBigInt],
   });
 
@@ -105,9 +91,8 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
 
     const loadMetadata = async () => {
       try {
-        setIsLoadingMetadata(true);
         for (const buildPath of METADATA_PATH_CANDIDATES) {
-          const url = `${IPFS_GATEWAY}/${buildPath(tokenId)}`;
+          const url = `${IPFS_GATEWAY}/${buildPath(item.tokenId)}`;
           try {
             const response = await fetch(url, { signal: controller.signal });
             if (!response.ok) {
@@ -125,11 +110,9 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
         setMetadata(null);
       } catch (error) {
         if ((error as Error).name !== "AbortError") {
-          console.error(`Failed to load metadata for token ${tokenId}`, error);
+          console.error(`Failed to load metadata for token ${item.tokenId}`, error);
         }
         setMetadata(null);
-      } finally {
-        setIsLoadingMetadata(false);
       }
     };
 
@@ -138,15 +121,17 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
     return () => {
       controller.abort();
     };
-  }, [tokenId]);
+  }, [item.tokenId]);
 
   const reservationInfo = reservationData as ReservationInfo | undefined;
   const reservedBy =
     reservationInfo?.buyer && reservationInfo.buyer !== ZERO_ADDRESS ? reservationInfo.buyer : undefined;
-  const statusLabel = isFulfilled ? "Fulfilled" : reservedBy ? "Reserved" : "Available";
-  const buyerLabel = formatAddress(reservedBy);
-  const fallbackImageUrl = `${IPFS_GATEWAY}/${COLLECTION_CID}/images/${tokenId}.png`;
+  const fallbackImageUrl = `${IPFS_GATEWAY}/${COLLECTION_CID}/images/${item.tokenId}.png`;
   const imageUrl = ipfsToHttp(metadata?.image) ?? fallbackImageUrl;
+  const isReserved = Boolean(reservedBy);
+  const mintedCount = isReserved ? 1 : 0;
+  const mintedPercent = mintedCount * 100;
+  const priceLabel = mintPrice ? Number.parseFloat(formatEther(mintPrice)).toFixed(3) : "--";
 
   const handleBuy = async () => {
     if (!mintPrice) return;
@@ -157,7 +142,7 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
         value: mintPrice,
       });
     } catch (error) {
-      console.error(`Failed to reserve token ${tokenId}`, error);
+      console.error(`Failed to reserve token ${item.tokenId}`, error);
     }
   };
 
@@ -165,17 +150,27 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
     <article className="overflow-hidden rounded-3xl bg-[#3a4553] p-5">
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[#20ff6d] text-black">
-            <ButterflyIcon color="#000" />
+          <div
+            className="relative flex h-14 w-14 items-center justify-center overflow-hidden rounded-full"
+            style={{ backgroundColor: item.backgroundColor }}
+          >
+            {imageUrl ? (
+              <Image
+                src={imageUrl}
+                alt={metadata?.name ?? `Token #${item.tokenId}`}
+                fill
+                sizes="56px"
+                className="object-cover"
+              />
+            ) : (
+              <ButterflyIcon color="#000" />
+            )}
           </div>
-          <div className="text-white">
-            <div className="text-sm uppercase tracking-widest text-[#cbd5f5]">Token</div>
-            <div className="text-3xl font-bold">#{tokenId.toString().padStart(3, "0")}</div>
-          </div>
+          <span className="text-3xl font-bold text-white">{item.label}</span>
         </div>
         <button
           type="button"
-          disabled={!isConnected || !mintPrice || isFulfilled || !!reservedBy || isMining}
+          disabled={!isConnected || !mintPrice || isReserved || isMining}
           className="flex items-center gap-2 rounded-full bg-[#20ff6d] px-8 py-3 text-sm font-bold text-black hover:bg-[#1ae058] disabled:opacity-50"
           onClick={handleBuy}
         >
@@ -186,42 +181,25 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
 
       <div className="border-t border-[#4a5562] mb-4"></div>
 
-      <div className="grid grid-cols-[120px_1fr] gap-4">
-        <div className="relative h-28 w-full overflow-hidden rounded-2xl bg-[#232d3a]">
-          {imageUrl ? (
-            <Image
-              src={imageUrl}
-              alt={metadata?.name ?? `Token #${tokenId}`}
-              fill
-              sizes="120px"
-              className="object-cover"
-            />
-          ) : (
-            <div className="flex h-full items-center justify-center text-xs text-[#9ca3b0]">
-              {isLoadingMetadata ? "Loading…" : "No preview"}
-            </div>
-          )}
-        </div>
+      <div className="mb-5 flex gap-4">
+        <span className="rounded-xl border border-[#20ff6d] bg-transparent px-4 py-2 text-sm font-medium text-[#20ff6d]">
+          Number
+        </span>
+        <span className="text-lg font-semibold text-white">1</span>
+        <span className="rounded-xl border border-[#20ff6d] bg-transparent px-4 py-2 text-sm font-medium text-[#20ff6d] ml-auto">
+          Price
+        </span>
+        <span className="flex items-center gap-2 text-lg font-semibold text-white">
+          {priceLabel}
+          <EthereumIcon />
+        </span>
+      </div>
 
-        <div className="flex flex-col justify-between text-sm text-[#e2e8f0]">
-          <div>
-            <div className="text-lg font-semibold text-white">{metadata?.name ?? `Token #${tokenId}`}</div>
-            <div className="mt-1 text-xs text-[#9ca3b0]">
-              {metadata?.description ?? "Metadata is not available yet."}
-            </div>
-          </div>
-          <div className="mt-4 flex flex-col gap-1">
-            <div className="flex justify-between">
-              <span className="text-[#9ca3b0]">Status</span>
-              <span className="font-medium text-white">{statusLabel}</span>
-            </div>
-            {buyerLabel && (
-              <div className="flex justify-between">
-                <span className="text-[#9ca3b0]">Reserved By</span>
-                <span className="font-mono text-xs text-[#20ff6d]">{buyerLabel}</span>
-              </div>
-            )}
-          </div>
+      <div className="space-y-3">
+        <Progress value={mintedPercent} />
+        <div className="flex justify-between text-sm text-[#9ca3b0]">
+          <span>Minted</span>
+          <span>{mintedCount} / 1</span>
         </div>
       </div>
     </article>
@@ -241,6 +219,29 @@ function CreditCardIcon() {
     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
       <rect x="2" y="5" width="20" height="14" rx="2" />
       <line x1="2" y1="10" x2="22" y2="10" />
+    </svg>
+  );
+}
+
+type ProgressProps = {
+  value: number;
+};
+
+function Progress({ value }: ProgressProps) {
+  return (
+    <div className="h-2 w-full overflow-hidden rounded-full bg-[#3d4854]">
+      <div className="h-full rounded-full bg-[#20ff6d]" style={{ width: `${Math.min(100, Math.max(0, value))}%` }} />
+    </div>
+  );
+}
+
+function EthereumIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+      <path d="M12 2L5.5 12.5L12 16.5L18.5 12.5L12 2Z" fill="#627EEA" />
+      <path d="M12 17.5L5.5 13.5L12 22L18.5 13.5L12 17.5Z" fill="#627EEA" opacity="0.6" />
+      <path d="M12 15.5L5.5 11.5L12 2V15.5Z" fill="#627EEA" opacity="0.45" />
+      <path d="M12 15.5L18.5 11.5L12 2V15.5Z" fill="#627EEA" opacity="0.8" />
     </svg>
   );
 }

--- a/packages/nextjs/app/nft/presale/page.tsx
+++ b/packages/nextjs/app/nft/presale/page.tsx
@@ -1,156 +1,245 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
+import Image from "next/image";
 import { ScreenHeader } from "@/components/layout/ScreenHeader";
-// import { Button } from "@/components/ui/button";
-import { parseEther, stringToHex } from "viem";
+import type { Address } from "viem";
+import { formatEther } from "viem";
 import { useAccount } from "wagmi";
-import { useTransactor } from "~~/hooks/scaffold-eth";
+import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 
-const presaleItems = [
-  {
-    id: "001",
-    minted: 290,
-    maxSupply: 1000,
-    priceEth: 0.01,
-    backgroundColor: "#c8860d",
-    iconColor: "#000",
-  },
-  {
-    id: "002",
-    minted: 480,
-    maxSupply: 1000,
-    priceEth: 0.01,
-    backgroundColor: "#4c6ef5",
-    iconColor: "#000",
-  },
-  {
-    id: "003",
-    minted: 160,
-    maxSupply: 1000,
-    priceEth: 0.01,
-    backgroundColor: "#66d9ef",
-    iconColor: "#000",
-  },
-  {
-    id: "004",
-    minted: 320,
-    maxSupply: 1000,
-    priceEth: 0.01,
-    backgroundColor: "#20ff6d",
-    iconColor: "#000",
-  },
-  {
-    id: "005",
-    minted: 780,
-    maxSupply: 1000,
-    priceEth: 0.01,
-    backgroundColor: "#ff8787",
-    iconColor: "#000",
-  },
-] satisfies PresaleItem[];
+const TOKEN_IDS = [1, 2, 3, 4, 5] as const;
+const METADATA_GATEWAY_BASE =
+  "https://ipfs.io/ipfs/bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/metadata";
+const IPFS_GATEWAY = "https://ipfs.io/ipfs";
 
-type PresaleItem = {
-  id: string;
-  minted: number;
-  maxSupply: number;
-  priceEth: number;
-  backgroundColor: string;
-  iconColor: string;
+type ReservationInfo = {
+  buyer: Address;
+  pricePaid: bigint;
+  reservedAt: bigint;
+  fulfilled: boolean;
+};
+
+type NftMetadata = {
+  name?: string;
+  description?: string;
+  image?: string;
+};
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+
+const formatAddress = (value: Address | undefined) => {
+  if (!value || value === ZERO_ADDRESS) {
+    return "";
+  }
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+};
+
+const ipfsToHttp = (uri?: string) => {
+  if (!uri) return undefined;
+  return uri.startsWith("ipfs://") ? uri.replace("ipfs://", `${IPFS_GATEWAY}/`) : uri;
 };
 
 export default function PresalePage() {
   const { isConnected } = useAccount();
-  const transactor = useTransactor();
 
-  const handleBuy = async (itemIndex: number) => {
-    try {
-      const message = `${Date.now()}#${itemIndex}`;
-      const data = stringToHex(message);
+  const { data: mintPrice } = useScaffoldReadContract({
+    contractName: "ButterflyPresale",
+    functionName: "mintPrice",
+  });
 
-      await transactor({
-        to: "0xcB135527801f88E5bF26CA25b2d9948b19927178",
-        value: parseEther("0.01"),
-        data,
-      });
-    } catch (error) {
-      console.error("Failed to send presale purchase transaction", error);
-    }
-  };
+  const { data: maxSupply } = useScaffoldReadContract({
+    contractName: "ButterflyPresale",
+    functionName: "maxSupply",
+  });
+
+  const { data: totalSupply } = useScaffoldReadContract({
+    contractName: "ButterflyPresale",
+    functionName: "totalSupply",
+  });
+
+  const { data: totalReservations } = useScaffoldReadContract({
+    contractName: "ButterflyPresale",
+    functionName: "totalReservations",
+  });
+
+  const formattedMintPrice = mintPrice ? formatEther(mintPrice) : undefined;
+  const reservedCount = Number(totalReservations ?? 0n);
+  const mintedCount = Number(totalSupply ?? 0n);
+  const maxCount = Number(maxSupply ?? 0n);
 
   return (
     <div className="min-h-screen bg-[#05060A] pb-24">
       <ScreenHeader title="Presale" />
       <div className="px-4 py-6">
         <div className="mx-auto max-w-md space-y-4">
-          {presaleItems.map((item, index) => {
-            const mintedPercent = Math.min(100, Math.round((item.minted / item.maxSupply) * 100));
-            return (
-              <article key={item.id} className="overflow-hidden rounded-3xl bg-[#3a4553] p-5">
-                <div className="flex items-center justify-between mb-6">
-                  <div className="flex items-center gap-4">
-                    <div
-                      className="flex h-14 w-14 items-center justify-center rounded-full"
-                      style={{ backgroundColor: item.backgroundColor }}
-                    >
-                      <ButterflyIcon color={item.iconColor} />
-                    </div>
-                    <span className="text-3xl font-bold text-white">{item.id}</span>
-                  </div>
-                  <button
-                    type="button"
-                    disabled={!isConnected}
-                    className="flex items-center gap-2 rounded-full bg-[#20ff6d] px-8 py-3 text-sm font-bold text-black hover:bg-[#1ae058] disabled:opacity-50"
-                    onClick={() => handleBuy(index)}
-                  >
-                    <CreditCardIcon />
-                    BUY
-                  </button>
-                </div>
+          <section className="rounded-3xl bg-[#1f2733] p-5 text-sm text-[#cbd5f5]">
+            <div className="flex justify-between">
+              <span>合约总量</span>
+              <span>{maxCount > 0 ? maxCount : "加载中…"}</span>
+            </div>
+            <div className="mt-2 flex justify-between">
+              <span>已铸造</span>
+              <span>{mintedCount}</span>
+            </div>
+            <div className="mt-2 flex justify-between">
+              <span>已预订</span>
+              <span>{reservedCount}</span>
+            </div>
+            <div className="mt-2 flex justify-between">
+              <span>单价</span>
+              <span>{formattedMintPrice ? `${formattedMintPrice} ETH` : "加载中…"}</span>
+            </div>
+          </section>
 
-                {/* 分割线 */}
-                <div className="border-t border-[#4a5562] mb-4"></div>
-
-                <div className="mb-5 flex gap-4">
-                  <span className="rounded-xl border border-[#20ff6d] bg-transparent px-4 py-2 text-sm font-medium text-[#20ff6d]">
-                    Number
-                  </span>
-                  <span className="text-lg font-semibold text-white">{item.maxSupply.toLocaleString()}</span>
-                  <span className="rounded-xl border border-[#20ff6d] bg-transparent px-4 py-2 text-sm font-medium text-[#20ff6d] ml-auto">
-                    Price
-                  </span>
-                  <span className="flex items-center gap-2 text-lg font-semibold text-white">
-                    {item.priceEth.toFixed(3)}
-                    <EthereumIcon />
-                  </span>
-                </div>
-
-                <div className="space-y-3">
-                  <Progress value={mintedPercent} />
-                  <div className="flex justify-between text-sm text-[#9ca3b0]">
-                    <span>Minted</span>
-                    <span>
-                      {item.minted.toLocaleString()} / {item.maxSupply.toLocaleString()}
-                    </span>
-                  </div>
-                </div>
-              </article>
-            );
-          })}
+          {TOKEN_IDS.map(tokenId => (
+            <PresaleItemCard key={tokenId} tokenId={tokenId} isConnected={isConnected} mintPrice={mintPrice} />
+          ))}
         </div>
       </div>
     </div>
   );
 }
 
-type ProgressProps = {
-  value: number;
+type PresaleItemCardProps = {
+  tokenId: number;
+  isConnected: boolean;
+  mintPrice: bigint | undefined;
 };
 
-function Progress({ value }: ProgressProps) {
+function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardProps) {
+  const [metadata, setMetadata] = useState<NftMetadata | null>(null);
+  const [isLoadingMetadata, setIsLoadingMetadata] = useState(true);
+
+  const tokenIdBigInt = useMemo(() => BigInt(tokenId), [tokenId]);
+
+  const { data: reservationData } = useScaffoldReadContract({
+    contractName: "ButterflyPresale",
+    functionName: "reservation",
+    args: [tokenIdBigInt],
+  });
+
+  const { data: isFulfilled } = useScaffoldReadContract({
+    contractName: "ButterflyPresale",
+    functionName: "isFulfilled",
+    args: [tokenIdBigInt],
+  });
+
+  const { writeContractAsync, isMining } = useScaffoldWriteContract({
+    contractName: "ButterflyPresale",
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadMetadata = async () => {
+      try {
+        setIsLoadingMetadata(true);
+        const response = await fetch(`${METADATA_GATEWAY_BASE}/${tokenId}.json`, { signal: controller.signal });
+        if (!response.ok) {
+          throw new Error(`Metadata request failed with status ${response.status}`);
+        }
+        const json = (await response.json()) as NftMetadata;
+        setMetadata(json);
+      } catch (error) {
+        if ((error as Error).name !== "AbortError") {
+          console.error(`Failed to load metadata for token ${tokenId}`, error);
+        }
+        setMetadata(null);
+      } finally {
+        setIsLoadingMetadata(false);
+      }
+    };
+
+    loadMetadata();
+
+    return () => {
+      controller.abort();
+    };
+  }, [tokenId]);
+
+  const reservationInfo = reservationData as ReservationInfo | undefined;
+  const reservedBy =
+    reservationInfo?.buyer && reservationInfo.buyer !== ZERO_ADDRESS ? reservationInfo.buyer : undefined;
+  const statusLabel = isFulfilled ? "已铸造" : reservedBy ? "已预订" : "可购买";
+  const buyerLabel = formatAddress(reservedBy);
+  const imageUrl = ipfsToHttp(metadata?.image);
+
+  const handleBuy = async () => {
+    if (!mintPrice) return;
+    try {
+      await writeContractAsync({
+        functionName: "reserve",
+        args: [tokenIdBigInt],
+        value: mintPrice,
+      });
+    } catch (error) {
+      console.error(`Failed to reserve token ${tokenId}`, error);
+    }
+  };
+
   return (
-    <div className="h-2 w-full overflow-hidden rounded-full bg-[#3d4854]">
-      <div className="h-full rounded-full bg-[#20ff6d]" style={{ width: `${value}%` }} />
-    </div>
+    <article className="overflow-hidden rounded-3xl bg-[#3a4553] p-5">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[#20ff6d] text-black">
+            <ButterflyIcon color="#000" />
+          </div>
+          <div className="text-white">
+            <div className="text-sm uppercase tracking-widest text-[#cbd5f5]">Token</div>
+            <div className="text-3xl font-bold">#{tokenId.toString().padStart(3, "0")}</div>
+          </div>
+        </div>
+        <button
+          type="button"
+          disabled={!isConnected || !mintPrice || isFulfilled || !!reservedBy || isMining}
+          className="flex items-center gap-2 rounded-full bg-[#20ff6d] px-8 py-3 text-sm font-bold text-black hover:bg-[#1ae058] disabled:opacity-50"
+          onClick={handleBuy}
+        >
+          <CreditCardIcon />
+          BUY
+        </button>
+      </div>
+
+      <div className="border-t border-[#4a5562] mb-4"></div>
+
+      <div className="grid grid-cols-[120px_1fr] gap-4">
+        <div className="relative h-28 w-full overflow-hidden rounded-2xl bg-[#232d3a]">
+          {imageUrl ? (
+            <Image
+              src={imageUrl}
+              alt={metadata?.name ?? `Token #${tokenId}`}
+              fill
+              sizes="120px"
+              className="object-cover"
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-xs text-[#9ca3b0]">
+              {isLoadingMetadata ? "加载中…" : "暂无预览"}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col justify-between text-sm text-[#e2e8f0]">
+          <div>
+            <div className="text-lg font-semibold text-white">{metadata?.name ?? `Token #${tokenId}`}</div>
+            <div className="mt-1 text-xs text-[#9ca3b0]">{metadata?.description ?? "等待揭示…"}</div>
+          </div>
+          <div className="mt-4 flex flex-col gap-1">
+            <div className="flex justify-between">
+              <span className="text-[#9ca3b0]">状态</span>
+              <span className="font-medium text-white">{statusLabel}</span>
+            </div>
+            {buyerLabel && (
+              <div className="flex justify-between">
+                <span className="text-[#9ca3b0]">预订地址</span>
+                <span className="font-mono text-xs text-[#20ff6d]">{buyerLabel}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
   );
 }
 
@@ -167,17 +256,6 @@ function CreditCardIcon() {
     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
       <rect x="2" y="5" width="20" height="14" rx="2" />
       <line x1="2" y1="10" x2="22" y2="10" />
-    </svg>
-  );
-}
-
-function EthereumIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-      <path d="M12 2L5.5 12.5L12 16.5L18.5 12.5L12 2Z" fill="#627EEA" />
-      <path d="M12 17.5L5.5 13.5L12 22L18.5 13.5L12 17.5Z" fill="#627EEA" opacity="0.6" />
-      <path d="M12 15.5L5.5 11.5L12 2V15.5Z" fill="#627EEA" opacity="0.45" />
-      <path d="M12 15.5L18.5 11.5L12 2V15.5Z" fill="#627EEA" opacity="0.8" />
     </svg>
   );
 }

--- a/packages/nextjs/app/nft/presale/page.tsx
+++ b/packages/nextjs/app/nft/presale/page.tsx
@@ -9,9 +9,14 @@ import { useAccount } from "wagmi";
 import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 
 const TOKEN_IDS = [1, 2, 3, 4, 5] as const;
-const METADATA_GATEWAY_BASE =
-  "https://ipfs.io/ipfs/bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u/metadata";
+const COLLECTION_CID = "bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u";
 const IPFS_GATEWAY = "https://ipfs.io/ipfs";
+const METADATA_PATH_CANDIDATES = [
+  (tokenId: number) => `${COLLECTION_CID}/metadata/${tokenId}.json`,
+  (tokenId: number) => `${COLLECTION_CID}/metadata/${tokenId}`,
+  (tokenId: number) => `${COLLECTION_CID}/json/${tokenId}.json`,
+  (tokenId: number) => `${COLLECTION_CID}/json/${tokenId}`,
+];
 
 type ReservationInfo = {
   buyer: Address;
@@ -75,20 +80,20 @@ export default function PresalePage() {
         <div className="mx-auto max-w-md space-y-4">
           <section className="rounded-3xl bg-[#1f2733] p-5 text-sm text-[#cbd5f5]">
             <div className="flex justify-between">
-              <span>合约总量</span>
-              <span>{maxCount > 0 ? maxCount : "加载中…"}</span>
+              <span>Collection Supply</span>
+              <span>{maxCount > 0 ? maxCount : "Loading…"}</span>
             </div>
             <div className="mt-2 flex justify-between">
-              <span>已铸造</span>
+              <span>Minted</span>
               <span>{mintedCount}</span>
             </div>
             <div className="mt-2 flex justify-between">
-              <span>已预订</span>
+              <span>Reserved</span>
               <span>{reservedCount}</span>
             </div>
             <div className="mt-2 flex justify-between">
-              <span>单价</span>
-              <span>{formattedMintPrice ? `${formattedMintPrice} ETH` : "加载中…"}</span>
+              <span>Mint Price</span>
+              <span>{formattedMintPrice ? `${formattedMintPrice} ETH` : "Loading…"}</span>
             </div>
           </section>
 
@@ -135,12 +140,23 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
     const loadMetadata = async () => {
       try {
         setIsLoadingMetadata(true);
-        const response = await fetch(`${METADATA_GATEWAY_BASE}/${tokenId}.json`, { signal: controller.signal });
-        if (!response.ok) {
-          throw new Error(`Metadata request failed with status ${response.status}`);
+        for (const buildPath of METADATA_PATH_CANDIDATES) {
+          const url = `${IPFS_GATEWAY}/${buildPath(tokenId)}`;
+          try {
+            const response = await fetch(url, { signal: controller.signal });
+            if (!response.ok) {
+              continue;
+            }
+            const json = (await response.json()) as NftMetadata;
+            setMetadata(json);
+            return;
+          } catch (innerError) {
+            if ((innerError as Error).name === "AbortError") {
+              throw innerError;
+            }
+          }
         }
-        const json = (await response.json()) as NftMetadata;
-        setMetadata(json);
+        setMetadata(null);
       } catch (error) {
         if ((error as Error).name !== "AbortError") {
           console.error(`Failed to load metadata for token ${tokenId}`, error);
@@ -161,9 +177,10 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
   const reservationInfo = reservationData as ReservationInfo | undefined;
   const reservedBy =
     reservationInfo?.buyer && reservationInfo.buyer !== ZERO_ADDRESS ? reservationInfo.buyer : undefined;
-  const statusLabel = isFulfilled ? "已铸造" : reservedBy ? "已预订" : "可购买";
+  const statusLabel = isFulfilled ? "Fulfilled" : reservedBy ? "Reserved" : "Available";
   const buyerLabel = formatAddress(reservedBy);
-  const imageUrl = ipfsToHttp(metadata?.image);
+  const fallbackImageUrl = `${IPFS_GATEWAY}/${COLLECTION_CID}/images/${tokenId}.png`;
+  const imageUrl = ipfsToHttp(metadata?.image) ?? fallbackImageUrl;
 
   const handleBuy = async () => {
     if (!mintPrice) return;
@@ -215,7 +232,7 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
             />
           ) : (
             <div className="flex h-full items-center justify-center text-xs text-[#9ca3b0]">
-              {isLoadingMetadata ? "加载中…" : "暂无预览"}
+              {isLoadingMetadata ? "Loading…" : "No preview"}
             </div>
           )}
         </div>
@@ -223,16 +240,18 @@ function PresaleItemCard({ tokenId, isConnected, mintPrice }: PresaleItemCardPro
         <div className="flex flex-col justify-between text-sm text-[#e2e8f0]">
           <div>
             <div className="text-lg font-semibold text-white">{metadata?.name ?? `Token #${tokenId}`}</div>
-            <div className="mt-1 text-xs text-[#9ca3b0]">{metadata?.description ?? "等待揭示…"}</div>
+            <div className="mt-1 text-xs text-[#9ca3b0]">
+              {metadata?.description ?? "Metadata is not available yet."}
+            </div>
           </div>
           <div className="mt-4 flex flex-col gap-1">
             <div className="flex justify-between">
-              <span className="text-[#9ca3b0]">状态</span>
+              <span className="text-[#9ca3b0]">Status</span>
               <span className="font-medium text-white">{statusLabel}</span>
             </div>
             {buyerLabel && (
               <div className="flex justify-between">
-                <span className="text-[#9ca3b0]">预订地址</span>
+                <span className="text-[#9ca3b0]">Reserved By</span>
                 <span className="font-mono text-xs text-[#20ff6d]">{buyerLabel}</span>
               </div>
             )}

--- a/packages/nextjs/app/nft/presale/page.tsx
+++ b/packages/nextjs/app/nft/presale/page.tsx
@@ -4,17 +4,23 @@ import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { ScreenHeader } from "@/components/layout/ScreenHeader";
 import type { Address } from "viem";
-import { formatEther } from "viem";
 import { useAccount } from "wagmi";
 import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 
-const PRESALE_ITEMS = [
-  { tokenId: 1, label: "001", backgroundColor: "#c8860d" },
-  { tokenId: 2, label: "002", backgroundColor: "#4c6ef5" },
-  { tokenId: 3, label: "003", backgroundColor: "#66d9ef" },
-  { tokenId: 4, label: "004", backgroundColor: "#20ff6d" },
-  { tokenId: 5, label: "005", backgroundColor: "#ff8787" },
-] as const;
+const CARD_COLORS = ["#c8860d", "#4c6ef5", "#66d9ef", "#20ff6d", "#ff8787"] as const;
+
+type PresaleItem = {
+  tokenId: number;
+  label: string;
+  backgroundColor: string;
+};
+
+const PRESALE_ITEMS: PresaleItem[] = Array.from({ length: 100 }, (_, index) => ({
+  tokenId: index + 1,
+  label: String(index + 1).padStart(3, "0"),
+  backgroundColor: CARD_COLORS[index % CARD_COLORS.length],
+}));
+const ITEMS_PER_PAGE = 10;
 const COLLECTION_CID = "bafybeiclu2xddpmbpgipirkjdrpxtnimpzm5a3cvfzlbpfa4irnyqfhf4u";
 const IPFS_GATEWAY = "https://ipfs.io/ipfs";
 const METADATA_PATH_CANDIDATES = [
@@ -51,14 +57,54 @@ export default function PresalePage() {
     functionName: "mintPrice",
   });
 
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.ceil(PRESALE_ITEMS.length / ITEMS_PER_PAGE);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const paginatedItems = useMemo(() => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    return PRESALE_ITEMS.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+  }, [currentPage]);
+
+  const goToPrevious = () => setCurrentPage(prev => Math.max(1, prev - 1));
+  const goToNext = () => setCurrentPage(prev => Math.min(totalPages, prev + 1));
+
   return (
     <div className="min-h-screen bg-[#05060A] pb-24">
       <ScreenHeader title="Presale" />
       <div className="px-4 py-6">
         <div className="mx-auto max-w-md space-y-4">
-          {PRESALE_ITEMS.map(item => (
+          {paginatedItems.map(item => (
             <PresaleItemCard key={item.tokenId} item={item} isConnected={isConnected} mintPrice={mintPrice} />
           ))}
+        </div>
+
+        <div className="mx-auto mt-8 flex max-w-md items-center justify-between text-white">
+          <button
+            type="button"
+            onClick={goToPrevious}
+            disabled={currentPage === 1}
+            className="rounded-full border border-[#4a5562] px-4 py-2 text-sm disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <span className="text-sm text-[#9ca3b0]">
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={goToNext}
+            disabled={currentPage === totalPages}
+            className="rounded-full border border-[#4a5562] px-4 py-2 text-sm disabled:opacity-50"
+          >
+            Next
+          </button>
         </div>
       </div>
     </div>
@@ -66,7 +112,7 @@ export default function PresalePage() {
 }
 
 type PresaleItemCardProps = {
-  item: (typeof PRESALE_ITEMS)[number];
+  item: PresaleItem;
   isConnected: boolean;
   mintPrice: bigint | undefined;
 };
@@ -131,7 +177,7 @@ function PresaleItemCard({ item, isConnected, mintPrice }: PresaleItemCardProps)
   const isReserved = Boolean(reservedBy);
   const mintedCount = isReserved ? 1 : 0;
   const mintedPercent = mintedCount * 100;
-  const priceLabel = mintPrice ? Number.parseFloat(formatEther(mintPrice)).toFixed(3) : "--";
+  const priceLabel = "0.01";
 
   const handleBuy = async () => {
     if (!mintPrice) return;
@@ -185,7 +231,7 @@ function PresaleItemCard({ item, isConnected, mintPrice }: PresaleItemCardProps)
         <span className="rounded-xl border border-[#20ff6d] bg-transparent px-4 py-2 text-sm font-medium text-[#20ff6d]">
           Number
         </span>
-        <span className="text-lg font-semibold text-white">1</span>
+        <span className="text-lg font-semibold text-white">1000</span>
         <span className="rounded-xl border border-[#20ff6d] bg-transparent px-4 py-2 text-sm font-medium text-[#20ff6d] ml-auto">
           Price
         </span>

--- a/packages/nextjs/app/nft/presale/page.tsx
+++ b/packages/nextjs/app/nft/presale/page.tsx
@@ -53,50 +53,16 @@ export default function PresalePage() {
     functionName: "mintPrice",
   });
 
-  const { data: maxSupply } = useScaffoldReadContract({
-    contractName: "ButterflyPresale",
-    functionName: "maxSupply",
-  });
-
-  const { data: totalSupply } = useScaffoldReadContract({
-    contractName: "ButterflyPresale",
-    functionName: "totalSupply",
-  });
-
-  const { data: totalReservations } = useScaffoldReadContract({
-    contractName: "ButterflyPresale",
-    functionName: "totalReservations",
-  });
-
   const formattedMintPrice = mintPrice ? formatEther(mintPrice) : undefined;
-  const reservedCount = Number(totalReservations ?? 0n);
-  const mintedCount = Number(totalSupply ?? 0n);
-  const maxCount = Number(maxSupply ?? 0n);
 
   return (
     <div className="min-h-screen bg-[#05060A] pb-24">
       <ScreenHeader title="Presale" />
       <div className="px-4 py-6">
         <div className="mx-auto max-w-md space-y-4">
-          <section className="rounded-3xl bg-[#1f2733] p-5 text-sm text-[#cbd5f5]">
-            <div className="flex justify-between">
-              <span>Collection Supply</span>
-              <span>{maxCount > 0 ? maxCount : "Loading…"}</span>
-            </div>
-            <div className="mt-2 flex justify-between">
-              <span>Minted</span>
-              <span>{mintedCount}</span>
-            </div>
-            <div className="mt-2 flex justify-between">
-              <span>Reserved</span>
-              <span>{reservedCount}</span>
-            </div>
-            <div className="mt-2 flex justify-between">
-              <span>Mint Price</span>
-              <span>{formattedMintPrice ? `${formattedMintPrice} ETH` : "Loading…"}</span>
-            </div>
-          </section>
-
+          <p className="text-center text-sm text-[#cbd5f5]">
+            Mint price: {formattedMintPrice ? `${formattedMintPrice} ETH` : "Loading…"}
+          </p>
           {TOKEN_IDS.map(tokenId => (
             <PresaleItemCard key={tokenId} tokenId={tokenId} isConnected={isConnected} mintPrice={mintPrice} />
           ))}

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -6,14 +6,39 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 
 const deployedContracts = {
   31337: {
-    YourContract: {
+    ButterflyPresale: {
       address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
       abi: [
         {
           inputs: [
             {
+              internalType: "string",
+              name: "name_",
+              type: "string",
+            },
+            {
+              internalType: "string",
+              name: "symbol_",
+              type: "string",
+            },
+            {
+              internalType: "string",
+              name: "baseTokenURI_",
+              type: "string",
+            },
+            {
+              internalType: "uint256",
+              name: "maxSupply_",
+              type: "uint256",
+            },
+            {
+              internalType: "uint256",
+              name: "mintPrice_",
+              type: "uint256",
+            },
+            {
               internalType: "address",
-              name: "_owner",
+              name: "treasury_",
               type: "address",
             },
           ],
@@ -26,20 +51,115 @@ const deployedContracts = {
             {
               indexed: true,
               internalType: "address",
-              name: "greetingSetter",
+              name: "owner",
+              type: "address",
+            },
+            {
+              indexed: true,
+              internalType: "address",
+              name: "approved",
+              type: "address",
+            },
+            {
+              indexed: true,
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "Approval",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "address",
+              name: "owner",
+              type: "address",
+            },
+            {
+              indexed: true,
+              internalType: "address",
+              name: "operator",
               type: "address",
             },
             {
               indexed: false,
+              internalType: "bool",
+              name: "approved",
+              type: "bool",
+            },
+          ],
+          name: "ApprovalForAll",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: false,
               internalType: "string",
-              name: "newGreeting",
+              name: "newBaseURI",
               type: "string",
+            },
+          ],
+          name: "BaseURIUpdated",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "address",
+              name: "to",
+              type: "address",
             },
             {
               indexed: false,
-              internalType: "bool",
-              name: "premium",
-              type: "bool",
+              internalType: "uint256",
+              name: "amount",
+              type: "uint256",
+            },
+          ],
+          name: "FundsWithdrawn",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "address",
+              name: "previousOwner",
+              type: "address",
+            },
+            {
+              indexed: true,
+              internalType: "address",
+              name: "newOwner",
+              type: "address",
+            },
+          ],
+          name: "OwnershipTransferred",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "address",
+              name: "buyer",
+              type: "address",
+            },
+            {
+              indexed: true,
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
             },
             {
               indexed: false,
@@ -48,12 +168,226 @@ const deployedContracts = {
               type: "uint256",
             },
           ],
-          name: "GreetingChange",
+          name: "ReservationCreated",
           type: "event",
         },
         {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "address",
+              name: "buyer",
+              type: "address",
+            },
+            {
+              indexed: true,
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "ReservationFulfilled",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "address",
+              name: "from",
+              type: "address",
+            },
+            {
+              indexed: true,
+              internalType: "address",
+              name: "to",
+              type: "address",
+            },
+            {
+              indexed: true,
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "Transfer",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "address",
+              name: "treasury",
+              type: "address",
+            },
+          ],
+          name: "TreasuryUpdated",
+          type: "event",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "to",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "approve",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "owner",
+              type: "address",
+            },
+          ],
+          name: "balanceOf",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "fulfillReservation",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "getApproved",
+          outputs: [
+            {
+              internalType: "address",
+              name: "",
+              type: "address",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "owner",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "operator",
+              type: "address",
+            },
+          ],
+          name: "isApprovedForAll",
+          outputs: [
+            {
+              internalType: "bool",
+              name: "",
+              type: "bool",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "isFulfilled",
+          outputs: [
+            {
+              internalType: "bool",
+              name: "",
+              type: "bool",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "isReserved",
+          outputs: [
+            {
+              internalType: "bool",
+              name: "",
+              type: "bool",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
           inputs: [],
-          name: "greeting",
+          name: "maxSupply",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [],
+          name: "mintPrice",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [],
+          name: "name",
           outputs: [
             {
               internalType: "string",
@@ -78,8 +412,182 @@ const deployedContracts = {
           type: "function",
         },
         {
-          inputs: [],
-          name: "premium",
+          inputs: [
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "ownerOf",
+          outputs: [
+            {
+              internalType: "address",
+              name: "",
+              type: "address",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "reserve",
+          outputs: [],
+          stateMutability: "payable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "reservation",
+          outputs: [
+            {
+              components: [
+                {
+                  internalType: "address",
+                  name: "buyer",
+                  type: "address",
+                },
+                {
+                  internalType: "uint96",
+                  name: "pricePaid",
+                  type: "uint96",
+                },
+                {
+                  internalType: "uint64",
+                  name: "reservedAt",
+                  type: "uint64",
+                },
+                {
+                  internalType: "bool",
+                  name: "fulfilled",
+                  type: "bool",
+                },
+              ],
+              internalType: "struct ButterflyPresale.Reservation",
+              name: "",
+              type: "tuple",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "from",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "to",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "safeTransferFrom",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "from",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "to",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+            {
+              internalType: "bytes",
+              name: "data",
+              type: "bytes",
+            },
+          ],
+          name: "safeTransferFrom",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "operator",
+              type: "address",
+            },
+            {
+              internalType: "bool",
+              name: "approved",
+              type: "bool",
+            },
+          ],
+          name: "setApprovalForAll",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "string",
+              name: "newBaseTokenURI",
+              type: "string",
+            },
+          ],
+          name: "setBaseTokenURI",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "newTreasury",
+              type: "address",
+            },
+          ],
+          name: "setTreasury",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "bytes4",
+              name: "interfaceId",
+              type: "bytes4",
+            },
+          ],
+          name: "supportsInterface",
           outputs: [
             {
               internalType: "bool",
@@ -91,21 +599,27 @@ const deployedContracts = {
           type: "function",
         },
         {
-          inputs: [
+          inputs: [],
+          name: "symbol",
+          outputs: [
             {
               internalType: "string",
-              name: "_newGreeting",
+              name: "",
               type: "string",
             },
           ],
-          name: "setGreeting",
-          outputs: [],
-          stateMutability: "payable",
+          stateMutability: "view",
           type: "function",
         },
         {
-          inputs: [],
-          name: "totalCounter",
+          inputs: [
+            {
+              internalType: "uint256",
+              name: "index",
+              type: "uint256",
+            },
+          ],
+          name: "tokenByIndex",
           outputs: [
             {
               internalType: "uint256",
@@ -120,11 +634,48 @@ const deployedContracts = {
           inputs: [
             {
               internalType: "address",
-              name: "",
+              name: "owner",
               type: "address",
             },
+            {
+              internalType: "uint256",
+              name: "index",
+              type: "uint256",
+            },
           ],
-          name: "userGreetingCounter",
+          name: "tokenOfOwnerByIndex",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "tokenURI",
+          outputs: [
+            {
+              internalType: "string",
+              name: "",
+              type: "string",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [],
+          name: "totalReservations",
           outputs: [
             {
               internalType: "uint256",
@@ -137,14 +688,65 @@ const deployedContracts = {
         },
         {
           inputs: [],
-          name: "withdraw",
+          name: "totalSupply",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "from",
+              type: "address",
+            },
+            {
+              internalType: "address",
+              name: "to",
+              type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "tokenId",
+              type: "uint256",
+            },
+          ],
+          name: "transferFrom",
           outputs: [],
           stateMutability: "nonpayable",
           type: "function",
         },
         {
-          stateMutability: "payable",
-          type: "receive",
+          inputs: [],
+          name: "treasury",
+          outputs: [
+            {
+              internalType: "address",
+              name: "",
+              type: "address",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "recipient",
+              type: "address",
+            },
+          ],
+          name: "withdraw",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
         },
       ],
       inheritedFunctions: {},

--- a/packages/nextjs/next.config.ts
+++ b/packages/nextjs/next.config.ts
@@ -9,6 +9,15 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: process.env.NEXT_PUBLIC_IGNORE_BUILD_ERROR === "true",
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "ipfs.io",
+        pathname: "/ipfs/**",
+      },
+    ],
+  },
   webpack: config => {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     config.externals.push("pino-pretty", "lokijs", "encoding");


### PR DESCRIPTION
## Summary
- add a ButterflyPresale ERC-721 contract with reservation, fulfilment, and deployment wiring
- split the NFT metadata into per-token JSON files that reference the uploaded IPFS CID
- refactor the presale UI to read on-chain state, fetch IPFS metadata, and load IPFS images

## Testing
- yarn lint
- yarn workspace @se-2/hardhat compile *(fails: Hardhat could not download the Solidity compiler because the proxy returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cc09a666d48321a0ec90af28717887