### PR TITLE
feat: add invite promotion flow

### DIFF
--- a/packages/nextjs/app/nft/presale/page.tsx
+++ b/packages/nextjs/app/nft/presale/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
-import { useSearchParams } from "next/navigation";
 import { ScreenHeader } from "@/components/layout/ScreenHeader";
 import {
   INVITE_PARAM_KEY,
@@ -59,8 +58,6 @@ const ipfsToHttp = (uri?: string) => {
 };
 
 export default function PresalePage() {
-  const searchParams = useSearchParams();
-  const inviteParam = searchParams.get(INVITE_PARAM_KEY);
   const { address, isConnected } = useAccount();
   const [inviteCode, setInviteCode] = useState<string | null>(null);
   const [isInviteReady, setIsInviteReady] = useState(false);
@@ -70,7 +67,8 @@ export default function PresalePage() {
       return;
     }
 
-    const normalizedParam = normalizeInviteCode(inviteParam);
+    const params = new URLSearchParams(window.location.search);
+    const normalizedParam = normalizeInviteCode(params.get(INVITE_PARAM_KEY));
     if (normalizedParam) {
       storeInviteCode(normalizedParam);
       setInviteCode(normalizedParam);
@@ -81,7 +79,7 @@ export default function PresalePage() {
     const stored = getStoredInviteCode();
     setInviteCode(stored);
     setIsInviteReady(true);
-  }, [inviteParam]);
+  }, []);
 
   const { data: mintPrice } = useScaffoldReadContract({
     contractName: "ButterflyPresale",

--- a/packages/nextjs/app/nft/presale/page.tsx
+++ b/packages/nextjs/app/nft/presale/page.tsx
@@ -2,7 +2,16 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
+import { useSearchParams } from "next/navigation";
 import { ScreenHeader } from "@/components/layout/ScreenHeader";
+import {
+  INVITE_PARAM_KEY,
+  PROMOTION_RULES,
+  getStoredInviteCode,
+  incrementReferralCount,
+  normalizeInviteCode,
+  storeInviteCode,
+} from "@/lib/invite";
 import type { Address } from "viem";
 import { useAccount } from "wagmi";
 import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
@@ -50,7 +59,29 @@ const ipfsToHttp = (uri?: string) => {
 };
 
 export default function PresalePage() {
-  const { isConnected } = useAccount();
+  const searchParams = useSearchParams();
+  const inviteParam = searchParams.get(INVITE_PARAM_KEY);
+  const { address, isConnected } = useAccount();
+  const [inviteCode, setInviteCode] = useState<string | null>(null);
+  const [isInviteReady, setIsInviteReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const normalizedParam = normalizeInviteCode(inviteParam);
+    if (normalizedParam) {
+      storeInviteCode(normalizedParam);
+      setInviteCode(normalizedParam);
+      setIsInviteReady(true);
+      return;
+    }
+
+    const stored = getStoredInviteCode();
+    setInviteCode(stored);
+    setIsInviteReady(true);
+  }, [inviteParam]);
 
   const { data: mintPrice } = useScaffoldReadContract({
     contractName: "ButterflyPresale",
@@ -75,13 +106,64 @@ export default function PresalePage() {
   const goToPrevious = () => setCurrentPage(prev => Math.max(1, prev - 1));
   const goToNext = () => setCurrentPage(prev => Math.min(totalPages, prev + 1));
 
+  if (!isInviteReady) {
+    return (
+      <div className="min-h-screen bg-[#05060A] pb-24">
+        <ScreenHeader title="Presale" />
+        <div className="px-4 py-6">
+          <div className="mx-auto max-w-md rounded-3xl border border-[#1f2432] bg-[#10131c] px-6 py-8 text-center text-sm text-[#9ca3b0]">
+            正在校验邀请链接...
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!inviteCode) {
+    return (
+      <div className="min-h-screen bg-[#05060A] pb-24">
+        <ScreenHeader title="Presale" />
+        <div className="px-4 py-6">
+          <div className="mx-auto max-w-md space-y-4 rounded-3xl border border-[#1f2432] bg-[#10131c] px-6 py-8 text-center text-white">
+            <h2 className="text-lg font-semibold uppercase tracking-[0.28em] text-[#20ff6d]">需要邀请码</h2>
+            <p className="text-sm text-[#9ca3b0]">请通过已购玩家提供的邀请链接访问DAPP后再参与Hash Butterfly预售。</p>
+            <ol className="space-y-2 text-xs text-[#9ca3b0]">
+              {PROMOTION_RULES.map((rule, index) => (
+                <li key={rule} className="flex gap-2 text-left">
+                  <span className="mt-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-[#20ff6d] text-[10px] font-semibold text-black">
+                    {index + 1}
+                  </span>
+                  <span>{rule}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const inviterDisplay = formatAddress(inviteCode);
+  const canPurchase = Boolean(inviteCode);
+
   return (
     <div className="min-h-screen bg-[#05060A] pb-24">
       <ScreenHeader title="Presale" />
       <div className="px-4 py-6">
+        <div className="mx-auto mb-6 max-w-md rounded-2xl border border-[#1f2432] bg-[#10131c] px-4 py-3 text-xs text-[#9ca3b0]">
+          当前邀请人：<span className="font-semibold text-white">{inviterDisplay}</span>
+        </div>
         <div className="mx-auto max-w-md space-y-4">
           {paginatedItems.map(item => (
-            <PresaleItemCard key={item.tokenId} item={item} isConnected={isConnected} mintPrice={mintPrice} />
+            <PresaleItemCard
+              key={item.tokenId}
+              item={item}
+              isConnected={isConnected}
+              mintPrice={mintPrice}
+              canPurchase={canPurchase}
+              inviteCode={inviteCode}
+              buyerAddress={address}
+            />
           ))}
         </div>
 
@@ -115,9 +197,19 @@ type PresaleItemCardProps = {
   item: PresaleItem;
   isConnected: boolean;
   mintPrice: bigint | undefined;
+  canPurchase: boolean;
+  inviteCode: string | null;
+  buyerAddress?: Address;
 };
 
-function PresaleItemCard({ item, isConnected, mintPrice }: PresaleItemCardProps) {
+function PresaleItemCard({
+  item,
+  isConnected,
+  mintPrice,
+  canPurchase,
+  inviteCode,
+  buyerAddress,
+}: PresaleItemCardProps) {
   const [metadata, setMetadata] = useState<NftMetadata | null>(null);
 
   const tokenIdBigInt = useMemo(() => BigInt(item.tokenId), [item.tokenId]);
@@ -178,15 +270,22 @@ function PresaleItemCard({ item, isConnected, mintPrice }: PresaleItemCardProps)
   const mintedCount = isReserved ? 1 : 0;
   const mintedPercent = mintedCount * 100;
   const priceLabel = "0.01";
+  const isBuyDisabled = !isConnected || !mintPrice || isReserved || isMining || !canPurchase;
 
   const handleBuy = async () => {
-    if (!mintPrice) return;
+    if (!mintPrice || !canPurchase) return;
     try {
       await writeContractAsync({
         functionName: "reserve",
         args: [tokenIdBigInt],
         value: mintPrice,
       });
+      if (inviteCode) {
+        const normalizedBuyer = buyerAddress?.toLowerCase();
+        if (!normalizedBuyer || normalizedBuyer !== inviteCode) {
+          incrementReferralCount(inviteCode);
+        }
+      }
     } catch (error) {
       console.error(`Failed to reserve token ${item.tokenId}`, error);
     }
@@ -216,13 +315,14 @@ function PresaleItemCard({ item, isConnected, mintPrice }: PresaleItemCardProps)
         </div>
         <button
           type="button"
-          disabled={!isConnected || !mintPrice || isReserved || isMining}
+          disabled={isBuyDisabled}
           className="flex items-center gap-2 rounded-full bg-[#20ff6d] px-8 py-3 text-sm font-bold text-black hover:bg-[#1ae058] disabled:opacity-50"
           onClick={handleBuy}
         >
           <CreditCardIcon />
           BUY
         </button>
+        {!canPurchase ? <p className="mt-2 text-xs text-[#ff5f66]">需要有效的邀请码才能购买。</p> : null}
       </div>
 
       <div className="border-t border-[#4a5562] mb-4"></div>
@@ -250,6 +350,13 @@ function PresaleItemCard({ item, isConnected, mintPrice }: PresaleItemCardProps)
       </div>
     </article>
   );
+}
+
+function formatAddress(value: string) {
+  if (value.length <= 10) {
+    return value;
+  }
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
 }
 
 function ButterflyIcon({ color }: { color: string }) {

--- a/packages/nextjs/app/wallet/page.tsx
+++ b/packages/nextjs/app/wallet/page.tsx
@@ -1,13 +1,22 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { ScreenHeader } from "@/components/layout/ScreenHeader";
 import { useWatchBalance } from "@/hooks/scaffold-eth/useWatchBalance";
+import {
+  INVITE_PARAM_KEY,
+  PROMOTION_RULES,
+  REFERRAL_EVENT_NAME,
+  createInviteCode,
+  getReferralCount,
+} from "@/lib/invite";
 import { cn } from "@/lib/utils";
 import { ConnectButton, useConnectModal } from "@rainbow-me/rainbowkit";
+import type { Address } from "viem";
 import { useAccount } from "wagmi";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
-const walletItems = [
+const BASE_WALLET_ITEMS = [
   {
     title: "ETH Balance",
     value: "0 ETH",
@@ -58,8 +67,77 @@ export default function WalletPage() {
     query: { enabled: Boolean(address) },
   });
 
+  const { data: ownedNftCount } = useScaffoldReadContract({
+    contractName: "ButterflyPresale",
+    functionName: "balanceOf",
+    args: [address] as readonly [Address | undefined],
+    query: {
+      enabled: Boolean(address),
+    },
+  });
+  const mintedCount = ownedNftCount ? Number(ownedNftCount) : 0;
+  const [referralCount, setReferralCount] = useState(0);
+
+  useEffect(() => {
+    if (!address) {
+      setReferralCount(0);
+      return;
+    }
+
+    const updateReferralCount = () => {
+      setReferralCount(getReferralCount(address));
+    };
+
+    updateReferralCount();
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== null && event.key !== "hb-referral-stats") {
+        return;
+      }
+      updateReferralCount();
+    };
+
+    const handleReferralEvent = (event: Event) => {
+      const customEvent = event as CustomEvent<{ address?: string }>;
+      const eventAddress = customEvent.detail?.address;
+      if (!eventAddress || !address) {
+        updateReferralCount();
+        return;
+      }
+      if (eventAddress.toLowerCase() === address.toLowerCase()) {
+        updateReferralCount();
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    window.addEventListener(REFERRAL_EVENT_NAME, handleReferralEvent);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener(REFERRAL_EVENT_NAME, handleReferralEvent);
+    };
+  }, [address]);
+
+  const walletItems = useMemo(() => {
+    return BASE_WALLET_ITEMS.map(item => {
+      if (item.title === "NFT") {
+        return { ...item, value: String(mintedCount) };
+      }
+      if (item.title === "Friends") {
+        return { ...item, value: String(referralCount) };
+      }
+      return item;
+    });
+  }, [mintedCount, referralCount]);
+
   const formattedBalance = balanceData ? formatBalanceForDisplay(balanceData) : undefined;
   const isConnected = Boolean(address && connectedChain);
+  const inviteCode = createInviteCode(address);
+  const hasInviteAccess = isConnected && mintedCount > 0;
   return (
     <div className="pb-24 pt-2 md:pb-16">
       <ScreenHeader title="Wallet" />
@@ -110,6 +188,13 @@ export default function WalletPage() {
             );
           })}
         </div>
+        <InviteLinkSection
+          isConnected={isConnected}
+          inviteCode={inviteCode}
+          mintedCount={mintedCount}
+          referralCount={referralCount}
+          hasInviteAccess={hasInviteAccess}
+        />
       </section>
     </div>
   );
@@ -179,6 +264,176 @@ function ConnectWalletCard({ item, balance }: ConnectWalletCardProps) {
         );
       }}
     </ConnectButton.Custom>
+  );
+}
+
+type InviteLinkSectionProps = {
+  isConnected: boolean;
+  inviteCode: string | null;
+  mintedCount: number;
+  referralCount: number;
+  hasInviteAccess: boolean;
+};
+
+function InviteLinkSection({
+  isConnected,
+  inviteCode,
+  mintedCount,
+  referralCount,
+  hasInviteAccess,
+}: InviteLinkSectionProps) {
+  const [inviteLink, setInviteLink] = useState<string | null>(null);
+  const [hasGenerated, setHasGenerated] = useState(false);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+
+  useEffect(() => {
+    if (!hasInviteAccess) {
+      setHasGenerated(false);
+      setCopyState("idle");
+    }
+  }, [hasInviteAccess]);
+
+  useEffect(() => {
+    if (!inviteCode || !hasInviteAccess) {
+      setInviteLink(null);
+      return;
+    }
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const url = new URL("/nft/presale", window.location.origin);
+      url.searchParams.set(INVITE_PARAM_KEY, inviteCode);
+      setInviteLink(url.toString());
+    } catch (error) {
+      console.error("Failed to create invite link", error);
+      setInviteLink(null);
+    }
+  }, [inviteCode, hasInviteAccess]);
+
+  useEffect(() => {
+    if (copyState !== "copied") {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setCopyState("idle");
+    }, 2500);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [copyState]);
+
+  const handleGenerate = async () => {
+    if (!inviteLink) {
+      return;
+    }
+
+    setHasGenerated(true);
+
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(inviteLink);
+        setCopyState("copied");
+        return;
+      } catch (error) {
+        console.error("Failed to copy invite link", error);
+      }
+    }
+
+    setCopyState("error");
+  };
+
+  const handleCopy = async () => {
+    if (!inviteLink) {
+      return;
+    }
+
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(inviteLink);
+        setCopyState("copied");
+        return;
+      } catch (error) {
+        console.error("Failed to copy invite link", error);
+      }
+    }
+
+    setCopyState("error");
+  };
+
+  const renderInviteContent = () => {
+    if (!isConnected) {
+      return <p className="text-sm text-[#9ca3b0]">连接钱包后即可查看您的推广状态。</p>;
+    }
+
+    if (!hasInviteAccess) {
+      return <p className="text-sm text-[#9ca3b0]">完成至少一枚NFT的购买后，即可生成专属邀请码并邀请好友加入。</p>;
+    }
+
+    return (
+      <div className="space-y-3">
+        <button
+          type="button"
+          onClick={handleGenerate}
+          className="w-full rounded-2xl bg-[#20ff6d] px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-black transition hover:bg-[#1ae058]"
+        >
+          {copyState === "copied" ? "邀请码已复制" : "生成邀请码"}
+        </button>
+        {hasGenerated && inviteLink ? (
+          <div className="rounded-2xl border border-[#1f2432] bg-[#141924] px-4 py-3">
+            <p className="text-xs text-[#9ca3b0]">分享以下链接邀请好友加入预售：</p>
+            <p className="mt-2 break-all font-mono text-xs text-[#20ff6d]">{inviteLink}</p>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="mt-3 w-full rounded-xl border border-[#20ff6d] px-3 py-2 text-xs font-semibold text-[#20ff6d] transition hover:bg-[#20ff6d]/10"
+            >
+              {copyState === "copied" ? "复制成功" : "复制链接"}
+            </button>
+          </div>
+        ) : null}
+        {copyState === "error" ? (
+          <p className="text-xs text-[#ff5f66]">浏览器无法自动复制，请手动选择上方链接进行复制。</p>
+        ) : null}
+      </div>
+    );
+  };
+
+  const rewardUnlocked = referralCount >= 1;
+
+  return (
+    <section className="rounded-3xl border border-[#1f2432] bg-[#10131c] px-6 py-6 text-white">
+      <h2 className="text-lg font-semibold uppercase tracking-[0.24em] text-[#20ff6d]">推广中心</h2>
+      <p className="mt-2 text-sm text-[#9ca3b0]">按照以下规则邀请好友加入Hash Butterfly生态：</p>
+      <ol className="mt-4 space-y-2 text-sm text-[#9ca3b0]">
+        {PROMOTION_RULES.map((rule, index) => (
+          <li key={rule} className="flex gap-2">
+            <span className="mt-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-[#20ff6d] text-[10px] font-semibold text-black">
+              {index + 1}
+            </span>
+            <span>{rule}</span>
+          </li>
+        ))}
+      </ol>
+      <div className="mt-6 space-y-3">
+        <div className="rounded-2xl border border-[#1f2432] bg-[#141924] px-4 py-3 text-sm text-[#9ca3b0]">
+          <p>
+            已购NFT数量：<span className="font-semibold text-white">{mintedCount}</span>
+          </p>
+          <p className="mt-2">
+            有效邀请人数：<span className="font-semibold text-white">{referralCount}</span>
+          </p>
+          <p className="mt-2 text-xs text-[#6c7280]">
+            {rewardUnlocked ? "已解锁邀请奖励，继续邀请可获得更多惊喜。" : "完成首个有效邀请后即可解锁邀请奖励。"}
+          </p>
+        </div>
+        {renderInviteContent()}
+      </div>
+    </section>
   );
 }
 

--- a/packages/nextjs/lib/invite.ts
+++ b/packages/nextjs/lib/invite.ts
@@ -1,0 +1,137 @@
+const INVITE_CODE_REGEX = /^0x[a-f0-9]{40}$/;
+
+const INVITE_STORAGE_KEY = "hb-invite-code";
+const REFERRAL_STORAGE_KEY = "hb-referral-stats";
+export const REFERRAL_EVENT_NAME = "hb-referral-updated";
+export const INVITE_PARAM_KEY = "invite";
+
+type ReferralStore = Record<string, number>;
+
+type ReferralEventDetail = {
+  address?: string;
+};
+
+const isBrowser = () => typeof window !== "undefined";
+
+export function normalizeInviteCode(code?: string | null): string | null {
+  if (!code) {
+    return null;
+  }
+  const normalized = code.trim().toLowerCase();
+  return INVITE_CODE_REGEX.test(normalized) ? normalized : null;
+}
+
+export function createInviteCode(address?: string | null): string | null {
+  return normalizeInviteCode(address);
+}
+
+export function isValidInviteCode(code?: string | null): boolean {
+  return normalizeInviteCode(code) !== null;
+}
+
+export function storeInviteCode(code: string) {
+  const normalized = normalizeInviteCode(code);
+  if (!normalized || !isBrowser()) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(INVITE_STORAGE_KEY, normalized);
+  } catch (error) {
+    console.error("Failed to store invite code", error);
+  }
+}
+
+export function getStoredInviteCode(): string | null {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(INVITE_STORAGE_KEY);
+    return normalizeInviteCode(stored);
+  } catch (error) {
+    console.error("Failed to read stored invite code", error);
+    return null;
+  }
+}
+
+function readReferralStore(): ReferralStore {
+  if (!isBrowser()) {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(REFERRAL_STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw) as ReferralStore;
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+
+    return Object.entries(parsed).reduce<ReferralStore>((acc, [address, value]) => {
+      const normalized = normalizeInviteCode(address);
+      if (!normalized) {
+        return acc;
+      }
+      const numericValue = Number(value);
+      acc[normalized] = Number.isFinite(numericValue) ? numericValue : 0;
+      return acc;
+    }, {});
+  } catch (error) {
+    console.error("Failed to parse referral store", error);
+    return {};
+  }
+}
+
+function writeReferralStore(store: ReferralStore) {
+  if (!isBrowser()) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(REFERRAL_STORAGE_KEY, JSON.stringify(store));
+  } catch (error) {
+    console.error("Failed to persist referral store", error);
+  }
+}
+
+function dispatchReferralEvent(address?: string) {
+  if (!isBrowser()) {
+    return;
+  }
+
+  const eventDetail: ReferralEventDetail = { address };
+  const event = new CustomEvent<ReferralEventDetail>(REFERRAL_EVENT_NAME, { detail: eventDetail });
+  window.dispatchEvent(event);
+}
+
+export function incrementReferralCount(inviterCode: string) {
+  const normalized = normalizeInviteCode(inviterCode);
+  if (!normalized) {
+    return;
+  }
+
+  const store = readReferralStore();
+  store[normalized] = (store[normalized] ?? 0) + 1;
+  writeReferralStore(store);
+  dispatchReferralEvent(normalized);
+}
+
+export function getReferralCount(address?: string | null): number {
+  const normalized = normalizeInviteCode(address);
+  if (!normalized) {
+    return 0;
+  }
+
+  const store = readReferralStore();
+  return store[normalized] ?? 0;
+}
+
+export const PROMOTION_RULES = [
+  "通过邀请链接登录DAPP才能购买",
+  "购买至少1枚NFT，才能拥有邀请链接",
+  "购买1枚推广后，才有邀请奖励",
+];


### PR DESCRIPTION
## Summary
- add reusable invitation utilities for storing codes and referral counts in local storage
- gate the presale flow behind invite links while recording successful referrals
- expose a promotion center on the wallet page to generate and copy invite links with referral stats

## Testing
- yarn next:lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7706b3cc8321a1956832c5d3b62b