### PR TITLE
Fetch NFT data on presale page

### DIFF
--- a/packages/nextjs/app/nft/presale/page.tsx
+++ b/packages/nextjs/app/nft/presale/page.tsx
@@ -52,6 +52,36 @@ const ipfsToHttp = (uri?: string) => {
 export default function PresalePage() {
   const { isConnected } = useAccount();
 
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const fetchNftData = async () => {
+      try {
+        const response = await fetch("http://59.110.161.193:8080/api/v1/nft", {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          console.error("Failed to fetch NFTs from API:", response.status, response.statusText);
+          return;
+        }
+
+        const data = await response.json();
+        console.log("Fetched NFT data from API:", data);
+      } catch (error) {
+        if ((error as Error).name !== "AbortError") {
+          console.error("Error fetching NFT data from API:", error);
+        }
+      }
+    };
+
+    void fetchNftData();
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
   const { data: mintPrice } = useScaffoldReadContract({
     contractName: "ButterflyPresale",
     functionName: "mintPrice",

--- a/packages/nextjs/scripts/fetchNft.mjs
+++ b/packages/nextjs/scripts/fetchNft.mjs
@@ -1,0 +1,22 @@
+const BASE_URL = "http://59.110.161.193:8080/api/v1";
+
+async function fetchNfts() {
+  try {
+    const response = await fetch(`${BASE_URL}/nft`);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Request failed with ${response.status}: ${errorText}`);
+    }
+
+    const data = await response.json();
+
+    console.log("Successfully fetched NFTs from API:");
+    console.log(JSON.stringify(data, null, 2));
+  } catch (error) {
+    console.error("Error fetching NFTs from API:", error);
+    process.exitCode = 1;
+  }
+}
+
+fetchNfts();


### PR DESCRIPTION
## Summary
- add a reusable Node script that requests the /nft endpoint from the provided API base URL
- log the response payload or a detailed error message to aid in debugging
- fetch the NFT API on the /nft presale page and log the payload without altering the UI

## Testing
- `yarn next:lint`


------
https://chatgpt.com/codex/tasks/task_e_68d138ed1a0c83218ab10d4f1390a23b