### PR TITLE
Improve mobile wallet connect modal and add TokenPocket support

### DIFF
--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AppProgressBar as ProgressBar } from "next-nprogress-bar";
@@ -28,6 +28,14 @@ const AppContainer = ({ children }: AppContainerProps) => {
   );
 };
 
+const RAINBOW_KIT_THEME_OPTIONS = {
+  accentColor: "#20ff6d",
+  accentColorForeground: "#05060a",
+  borderRadius: "large" as const,
+  fontStack: "system" as const,
+  overlayBlur: "small" as const,
+};
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -40,18 +48,42 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
   const { resolvedTheme } = useTheme();
   const isDarkMode = resolvedTheme === "dark";
   const [mounted, setMounted] = useState(false);
+  const [modalSize, setModalSize] = useState<"compact" | "wide">("wide");
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const updateModalSize = () => {
+      const nextSize: "compact" | "wide" = window.innerWidth <= 640 ? "compact" : "wide";
+      setModalSize(current => (current === nextSize ? current : nextSize));
+    };
+
+    updateModalSize();
+    window.addEventListener("resize", updateModalSize);
+
+    return () => {
+      window.removeEventListener("resize", updateModalSize);
+    };
+  }, []);
+
+  const rainbowKitTheme = useMemo(() => {
+    if (!mounted) {
+      return lightTheme(RAINBOW_KIT_THEME_OPTIONS);
+    }
+
+    return isDarkMode ? darkTheme(RAINBOW_KIT_THEME_OPTIONS) : lightTheme(RAINBOW_KIT_THEME_OPTIONS);
+  }, [isDarkMode, mounted]);
+
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider
-          avatar={BlockieAvatar}
-          theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
-        >
+        <RainbowKitProvider avatar={BlockieAvatar} modalSize={modalSize} theme={rainbowKitTheme}>
           <ProgressBar height="3px" color="#20ff6d" />
           <AppContainer>{children}</AppContainer>
         </RainbowKitProvider>

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -1,10 +1,12 @@
 import { connectorsForWallets } from "@rainbow-me/rainbowkit";
 import {
   coinbaseWallet,
+  injectedWallet,
   ledgerWallet,
   metaMaskWallet,
   rainbowWallet,
   safeWallet,
+  tokenPocketWallet,
   walletConnectWallet,
 } from "@rainbow-me/rainbowkit/wallets";
 import { rainbowkitBurnerWallet } from "burner-connector";
@@ -15,7 +17,9 @@ const { onlyLocalBurnerWallet, targetNetworks } = scaffoldConfig;
 
 const wallets = [
   metaMaskWallet,
+  injectedWallet,
   walletConnectWallet,
+  tokenPocketWallet,
   ledgerWallet,
   coinbaseWallet,
   rainbowWallet,

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -133,6 +133,30 @@ button {
   --rk-blurs-modalOverlay: blur(28px);
 }
 
+[data-rk] h1,
+[data-rk] h2,
+[data-rk] h3,
+[data-rk] h4,
+[data-rk] h5,
+[data-rk] h6 {
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+[data-rk] [data-testid^="rk-wallet-option-"] * {
+  min-width: 0;
+}
+
+[data-rk] [data-testid^="rk-wallet-option-"] [style*="max-width"] {
+  max-width: 100% !important;
+  white-space: normal;
+  word-break: break-word;
+}
+
+[data-rk] [data-testid^="rk-wallet-option-"] {
+  white-space: normal;
+}
+
 @media (max-width: 640px) {
   [data-rk] {
     --rk-colors-modalBackdrop: rgba(5, 6, 10, 0.82);
@@ -142,5 +166,40 @@ button {
   [data-rk] [role="dialog"] {
     border-radius: 32px 32px 0 0;
     border: 1px solid var(--hb-border-strong);
+  }
+
+  [data-rk] [role="dialog"] [data-testid^="rk-wallet-option-"] {
+    padding-inline: 12px;
+  }
+}
+
+@media (max-width: 540px) {
+  [data-rk] [role="dialog"] {
+    width: 100vw;
+    max-width: none;
+    margin: 0;
+  }
+
+  [data-rk] [role="dialog"] .ju367va.ju367v4.ju367v2r {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+    text-align: center;
+  }
+
+  [data-rk] [role="dialog"] .ju367va.ju367v4.ju367v2r > .ju367va {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  [data-rk] [role="dialog"] .ju367va.ju367v4.ju367v2r > .ju367va > * {
+    flex: 1 1 0;
+  }
+
+  [data-rk] [role="dialog"] .ju367va.ju367v4.ju367v2r > .ju367va > * > * {
+    width: 100%;
+    justify-content: center;
   }
 }

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -175,9 +175,11 @@ button {
 
 @media (max-width: 540px) {
   [data-rk] [role="dialog"] {
-    width: 100vw;
+    box-sizing: border-box;
+    width: min(420px, calc(100vw - 24px));
     max-width: none;
-    margin: 0;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   [data-rk] [role="dialog"] .ju367va.ju367v4.ju367v2r {

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -106,3 +106,41 @@ button {
     mask-composite: exclude;
   }
 }
+
+/* RainbowKit overrides */
+[data-rk] {
+  --rk-fonts-body: inherit;
+  --rk-colors-accentColor: var(--hb-green);
+  --rk-colors-accentColorForeground: #05060a;
+  --rk-colors-modalBackdrop: rgba(5, 6, 10, 0.72);
+  --rk-colors-modalBackground: var(--hb-surface-soft);
+  --rk-colors-modalBorder: var(--hb-border-strong);
+  --rk-colors-modalText: var(--hb-text-primary);
+  --rk-colors-modalTextSecondary: var(--hb-text-secondary);
+  --rk-colors-modalTextDim: var(--hb-text-subtle);
+  --rk-colors-actionButtonBorder: var(--hb-border);
+  --rk-colors-actionButtonBorderMobile: var(--hb-border);
+  --rk-colors-actionButtonSecondaryBackground: var(--hb-surface-muted);
+  --rk-colors-selectedOptionBorder: rgba(32, 255, 109, 0.4);
+  --rk-radii-actionButton: 16px;
+  --rk-radii-connectButton: 16px;
+  --rk-radii-menuButton: 16px;
+  --rk-radii-modal: 24px;
+  --rk-radii-modalMobile: 28px;
+  --rk-shadows-dialog: 0 24px 60px rgba(0, 0, 0, 0.45);
+  --rk-shadows-selectedOption: 0 0 0 1px rgba(32, 255, 109, 0.35);
+  --rk-shadows-walletLogo: 0 16px 40px rgba(0, 0, 0, 0.35);
+  --rk-blurs-modalOverlay: blur(28px);
+}
+
+@media (max-width: 640px) {
+  [data-rk] {
+    --rk-colors-modalBackdrop: rgba(5, 6, 10, 0.82);
+    --rk-radii-modalMobile: 32px;
+  }
+
+  [data-rk] [role="dialog"] {
+    border-radius: 32px 32px 0 0;
+    border: 1px solid var(--hb-border-strong);
+  }
+}


### PR DESCRIPTION
## Summary
- adjust RainbowKit provider theming and modal sizing to favour a compact experience on small screens
- override RainbowKit CSS tokens to match Hash Butterfly styling and polish the mobile dialog
- include TokenPocket and injected wallets in the connector list so the TokenPocket app can connect directly

## Testing
- yarn next:lint

------
https://chatgpt.com/codex/tasks/task_e_68eb56801f1083219cd2ffb2b0bb906f